### PR TITLE
fix: stabilize wallet connection and use sign-only tx flow

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,9 +25,12 @@ import { BatchTransactionsProvider } from './hooks/useBatchTransactions';
 import { BatchApprovalsProvider } from './hooks/useBatchApprovals';
 import { BatchExecutesProvider } from './hooks/useBatchExecutes';
 
-const App = () => {
-  const queryClient = new QueryClient();
+// Create the QueryClient once at module scope. Creating it inside the component
+// body would discard the entire query cache (RPC URL, multisig data, …) on every
+// re-render of App, which can cascade into connection/wallet resets.
+const queryClient = new QueryClient();
 
+const App = () => {
   // @ts-ignore
   return (
     <ThemeProvider>

--- a/src/components/ApproveButton.tsx
+++ b/src/components/ApproveButton.tsx
@@ -139,10 +139,18 @@ const ApproveButton = ({
       );
       transaction.recentBlockhash = freshBlockhash;
 
-      // If simulation passes, send the transaction with fresh blockhash
-      console.log('[ApproveButton] Sending transaction to wallet for approval');
+      // If simulation passes, sign with the wallet and broadcast via the app's
+      // connection. Signing only (instead of wallet.sendTransaction) means the
+      // wallet never broadcasts, so it doesn't need to be pointed at this
+      // network's RPC — the app always submits to the configured endpoint. This
+      // also avoids the "Plugin Closed" errors some wallets throw on send.
+      console.log('[ApproveButton] Requesting wallet signature');
+      if (!wallet.signTransaction) {
+        throw new Error('Wallet does not support transaction signing');
+      }
       const startSend = Date.now();
-      signature = await wallet.sendTransaction(transaction, connection, {
+      const signedTransaction = await wallet.signTransaction(transaction);
+      signature = await connection.sendRawTransaction(signedTransaction.serialize(), {
         skipPreflight: false,
         maxRetries: 3,
       });
@@ -194,12 +202,6 @@ const ApproveButton = ({
         queryClient.invalidateQueries({ queryKey: ['proposal'] }),
         queryClient.invalidateQueries({ queryKey: ['transaction-details'] }),
       ]);
-
-      // Force a page reload after a short delay to ensure all data is fresh
-      console.log('[ApproveButton] Scheduling page reload');
-      setTimeout(() => {
-        window.location.reload();
-      }, 1500);
 
       // Return success with signature
       console.log('[ApproveButton] Approval completed successfully');

--- a/src/components/CancelButton.tsx
+++ b/src/components/CancelButton.tsx
@@ -126,10 +126,18 @@ const CancelButton = ({
       );
       transaction.recentBlockhash = freshBlockhash;
 
-      // If simulation passes, send the transaction with fresh blockhash
-      console.log('[CancelButton] Sending transaction to wallet for approval');
+      // If simulation passes, sign with the wallet and broadcast via the app's
+      // connection. Signing only (instead of wallet.sendTransaction) means the
+      // wallet never broadcasts, so it doesn't need to be pointed at this
+      // network's RPC — the app always submits to the configured endpoint. This
+      // also avoids the "Plugin Closed" errors some wallets throw on send.
+      console.log('[CancelButton] Requesting wallet signature');
+      if (!wallet.signTransaction) {
+        throw new Error('Wallet does not support transaction signing');
+      }
       const startSend = Date.now();
-      signature = await wallet.sendTransaction(transaction, connection, {
+      const signedTransaction = await wallet.signTransaction(transaction);
+      signature = await connection.sendRawTransaction(signedTransaction.serialize(), {
         skipPreflight: false,
         maxRetries: 3,
       });
@@ -182,12 +190,6 @@ const CancelButton = ({
         queryClient.invalidateQueries({ queryKey: ['proposal'] }),
         queryClient.invalidateQueries({ queryKey: ['transaction-details'] }),
       ]);
-
-      // Force a page reload after a short delay to ensure all data is fresh
-      console.log('[CancelButton] Scheduling page reload');
-      setTimeout(() => {
-        window.location.reload();
-      }, 1500);
 
       // Return success with signature
       console.log('[CancelButton] Cancellation completed successfully');

--- a/src/components/ExecuteButton.tsx
+++ b/src/components/ExecuteButton.tsx
@@ -451,12 +451,6 @@ const ExecuteButton = ({
       queryClient.invalidateQueries({ queryKey: ['transaction-details'] }),
     ]);
 
-    // Force a page reload after a short delay to ensure all data is fresh
-    console.log('[ExecuteButton] Scheduling page reload');
-    setTimeout(() => {
-      window.location.reload();
-    }, 1500);
-
     // Return success result
     console.log('[ExecuteButton] Execution completed successfully');
     return {

--- a/src/components/RejectButton.tsx
+++ b/src/components/RejectButton.tsx
@@ -147,10 +147,18 @@ const RejectButton = ({
       );
       transaction.recentBlockhash = freshBlockhash;
 
-      // If simulation passes, send the transaction with fresh blockhash
-      console.log('[RejectButton] Sending transaction to wallet for approval');
+      // If simulation passes, sign with the wallet and broadcast via the app's
+      // connection. Signing only (instead of wallet.sendTransaction) means the
+      // wallet never broadcasts, so it doesn't need to be pointed at this
+      // network's RPC — the app always submits to the configured endpoint. This
+      // also avoids the "Plugin Closed" errors some wallets throw on send.
+      console.log('[RejectButton] Requesting wallet signature');
+      if (!wallet.signTransaction) {
+        throw new Error('Wallet does not support transaction signing');
+      }
       const startSend = Date.now();
-      signature = await wallet.sendTransaction(transaction, connection, {
+      const signedTransaction = await wallet.signTransaction(transaction);
+      signature = await connection.sendRawTransaction(signedTransaction.serialize(), {
         skipPreflight: false,
         maxRetries: 3,
       });
@@ -210,12 +218,6 @@ const RejectButton = ({
         queryClient.invalidateQueries({ queryKey: ['proposal'] }),
         queryClient.invalidateQueries({ queryKey: ['transaction-details'] }),
       ]);
-
-      // Force a page reload after a short delay to ensure all data is fresh
-      console.log('[RejectButton] Scheduling page reload');
-      setTimeout(() => {
-        window.location.reload();
-      }, 1500);
 
       // Return success with signature
       console.log('[RejectButton] Rejection completed successfully');

--- a/src/components/Wallet.tsx
+++ b/src/components/Wallet.tsx
@@ -1,11 +1,9 @@
 'use client';
-import React, { FC, useMemo, useEffect, useState } from 'react';
+import React, { FC, useCallback, useMemo } from 'react';
 import { ConnectionProvider, WalletProvider } from '@solana/wallet-adapter-react';
 import { WalletModalProvider } from '@solana/wallet-adapter-react-ui';
-import {
-  TorusWalletAdapter,
-  LedgerWalletAdapter,
-} from '@solana/wallet-adapter-wallets';
+import { WalletError } from '@solana/wallet-adapter-base';
+import { TorusWalletAdapter, LedgerWalletAdapter } from '@solana/wallet-adapter-wallets';
 import { getRpcUrl } from '@/hooks/useSettings';
 
 import '@solana/wallet-adapter-react-ui/styles.css';
@@ -15,41 +13,31 @@ type Props = {
 };
 
 export const Wallet: FC<Props> = ({ children }) => {
-  const [walletsReady, setWalletsReady] = useState(false);
-
-  // Use the same RPC URL configured in app settings (localStorage).
-  // This ensures the wallet adapter connects to the same network the app is using,
-  // so users don't have to manually switch networks in their wallet.
+  // RPC endpoint for the wallet-adapter ConnectionProvider. Read once at mount.
+  // The app's reactive connection (which follows RPC changes made in Settings)
+  // lives in useMultisigData; this endpoint only backs the wallet-adapter context.
   const endpoint = useMemo(() => getRpcUrl(), []);
 
-  // Delay wallet initialization to allow browser extensions to register
-  useEffect(() => {
-    // Give browser extensions time to inject and register with the wallet standard
-    const timer = setTimeout(() => {
-      setWalletsReady(true);
-    }, 100);
+  // Wallets that implement the Wallet Standard (Phantom, Solflare, Backpack, …)
+  // are detected automatically and must NOT be listed here. Only register legacy
+  // adapters that don't implement the standard.
+  //
+  // This array must be referentially stable: swapping it after mount forces
+  // WalletProvider to re-initialize and races with autoConnect, which is a
+  // primary cause of spurious disconnects. (Previously this was delayed behind a
+  // 100ms timer and went from [] -> [adapters]; that swap was the bug.)
+  const wallets = useMemo(() => [new LedgerWalletAdapter(), new TorusWalletAdapter()], []);
 
-    return () => clearTimeout(timer);
+  // autoConnect can surface benign errors (user hasn't authorized the site yet,
+  // a wallet isn't ready, etc.). Swallow them as warnings instead of letting them
+  // bubble up as uncaught errors / scary console noise.
+  const onError = useCallback((error: WalletError) => {
+    console.warn('[wallet-adapter]', error.name, error.message);
   }, []);
-
-  const wallets = useMemo(
-    () => {
-      if (!walletsReady) return [];
-
-      // Wallets that support the Wallet Standard (Phantom, Solflare, Backpack, etc.)
-      // are detected automatically and don't need legacy adapter registration.
-      // Only include adapters for wallets that don't implement the standard.
-      return [
-        new TorusWalletAdapter(),
-        new LedgerWalletAdapter(),
-      ];
-    },
-    [walletsReady]
-  );
 
   return (
     <ConnectionProvider endpoint={endpoint}>
-      <WalletProvider wallets={wallets} autoConnect>
+      <WalletProvider wallets={wallets} onError={onError} autoConnect>
         <WalletModalProvider>{children}</WalletModalProvider>
       </WalletProvider>
     </ConnectionProvider>

--- a/src/components/validators/ChangeAuthorityDialog.tsx
+++ b/src/components/validators/ChangeAuthorityDialog.tsx
@@ -16,7 +16,7 @@ import { ValidatorInfo } from '@/lib/validators/validatorUtils';
 import { createAuthorizeWithdrawerInstruction } from '@/lib/validators/validatorInstructions';
 import { useMultisigData } from '@/hooks/useMultisigData';
 import { useMultisig } from '@/hooks/useServices';
-import { useConnection, useWallet } from '@solana/wallet-adapter-react';
+import { useWallet } from '@solana/wallet-adapter-react';
 import { PublicKey, TransactionMessage, VersionedTransaction } from '@solana/web3.js';
 import * as multisig from '@sqds/multisig';
 import { toast } from 'sonner';

--- a/src/components/validators/ChangeCommissionDialog.tsx
+++ b/src/components/validators/ChangeCommissionDialog.tsx
@@ -16,7 +16,7 @@ import { ValidatorInfo } from '@/lib/validators/validatorUtils';
 import { createUpdateCommissionInstruction } from '@/lib/validators/validatorInstructions';
 import { useMultisigData } from '@/hooks/useMultisigData';
 import { useMultisig } from '@/hooks/useServices';
-import { useConnection, useWallet } from '@solana/wallet-adapter-react';
+import { useWallet } from '@solana/wallet-adapter-react';
 import { PublicKey, TransactionMessage, VersionedTransaction } from '@solana/web3.js';
 import * as multisig from '@sqds/multisig';
 import { toast } from 'sonner';

--- a/src/components/validators/WithdrawRewardsDialog.tsx
+++ b/src/components/validators/WithdrawRewardsDialog.tsx
@@ -16,7 +16,7 @@ import { ValidatorInfo } from '@/lib/validators/validatorUtils';
 import { createWithdrawInstruction } from '@/lib/validators/validatorInstructions';
 import { useMultisigData } from '@/hooks/useMultisigData';
 import { useMultisig } from '@/hooks/useServices';
-import { useConnection, useWallet } from '@solana/wallet-adapter-react';
+import { useWallet } from '@solana/wallet-adapter-react';
 import { PublicKey, LAMPORTS_PER_SOL, TransactionMessage, VersionedTransaction } from '@solana/web3.js';
 import * as multisig from '@sqds/multisig';
 import { toast } from 'sonner';


### PR DESCRIPTION
## Summary

Addresses two long-standing wallet pain points: the wallet **constantly disconnecting**, and having to **manually switch the RPC inside the wallet** when using the app across X1 mainnet / X1 testnet / Solana mainnet.

## Root causes & fixes

**Disconnects**
1. `Wallet.tsx` swapped the `wallets` array after mount — a 100ms timer flipped it from `[]` → `[Torus, Ledger]`, changing the array identity and forcing `WalletProvider` to re-initialize *after* `autoConnect` had already run. Now a referentially-stable `useMemo(() => [...], [])` array with no timer. (Wallet Standard wallets — Phantom/Solflare/Backpack — auto-detect and are intentionally not listed.)
2. `window.location.reload()` ran after every approve/reject/cancel/execute. Each reload re-mounted the provider tree and re-ran `autoConnect` (which kept failing due to #1). Removed — the handlers already `invalidateQueries(...)` to refresh data.
3. `new QueryClient()` was created in the `App` render body; hoisted to module scope so a re-render can't blow away the cache.

**Having to switch the wallet's RPC**
- X1 is a Solana fork (different genesis/blockhash, same address + tx format). `approve`/`reject`/`cancel` used `wallet.sendTransaction(tx, connection)`, which makes the **wallet broadcast** via its own active RPC — so if the wallet was on Solana, the X1 blockhash was invalid and users had to repoint their wallet's RPC.
- Converted those three to the **sign-only** pattern already used by the other ~19 components: `wallet.signTransaction(tx)` + `connection.sendRawTransaction(...)`. The wallet now only signs; the app always broadcasts to the configured endpoint.

**Cleanup**
- Removed unused `useConnection` imports from the three validator dialogs (they already use `useMultisigData().connection`).

## Caveat
Phantom still *simulates* against its own active network for the approval preview, so on an X1 fork it may still show a cosmetic "unable to simulate / may fail" notice — that can't be suppressed dApp-side. The difference is signing + app-side broadcast now succeeds regardless of the wallet's selected network. Solflare/Backpack honor the dApp connection more faithfully.

## Test plan

**A. Disconnect / reconnect stability**
1. `yarn dev`, open the app, connect a wallet (Phantom or Solflare).
2. Hard-refresh (Cmd-Shift-R) → wallet should **auto-reconnect** without re-prompting.
3. Navigate between routes (Home → Transactions → Programs → Settings) → stays connected.
4. Approve (or reject/cancel/execute) a proposal → after success the page **does NOT full-reload**; the list/detail updates in place and the wallet stays connected.
5. Leave the tab idle a few minutes, come back → still connected.

**B. No wallet-RPC switch needed (the multi-chain win)**
6. In your wallet, set the active network to **Solana Mainnet** (the "wrong" network on purpose). Do **not** add/select an X1 custom RPC.
7. In the app (pointed at X1 via Settings or the X1 domain), approve/reject/cancel a proposal.
8. Expected: you get a **signature** prompt (not a send prompt), it broadcasts, and the tx confirms on X1 — **without** changing the wallet's RPC. (A cosmetic Phantom "may fail to simulate" warning is OK and expected — see Caveat.)
9. Repeat for **execute** and a **send SOL / send token** flow to confirm those still work (they were already sign-only).

**C. Settings / network switching**
10. Settings → change RPC URL → app data follows the new RPC immediately (no manual reload needed).
11. NetworkSwitcher → switching networks redirects to the matching `multisig.*.x1.xyz` domain as before.

**D. Sanity**
12. `yarn build` succeeds (verified locally — green, only pre-existing bundle-size warnings).