### PR TITLE
feat: per-network env files + per-network settings namespacing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,25 @@
-# Copy this file to .env and customize the values
+# ============================================================================
+# Network selection
+# ----------------------------------------------------------------------------
+# This app runs against multiple networks from one codebase. Each network has
+# its own env file, selected by the APP_NETWORK variable at build time:
+#
+#   .env.testnet         <- yarn dev:testnet         (also the default `yarn dev`)
+#   .env.mainnet         <- yarn dev:mainnet          (X1 Mainnet)
+#   .env.solana-mainnet  <- yarn dev:solana-mainnet   (Solana Mainnet)
+#
+# Build equivalents: yarn build:testnet / build:mainnet / build:solana-mainnet.
+# Copy this file to the per-network file you need (e.g. .env.testnet) and fill
+# in the values. All .env* files except this example are gitignored.
+#
+# Note: values you change in the app's Settings page are saved to localStorage,
+# namespaced per network (e.g. x-rpc-url:testnet). Switching networks locally
+# therefore no longer leaks one network's RPC/program override into another. An
+# override you set for a given network persists for that network until changed.
+#
+# On Vercel, APP_NETWORK is unset and these APP_* vars come from the project's
+# dashboard env settings instead of a file.
+# ============================================================================
 
 # Solana RPC URL
 APP_RPC_URL=https://rpc.testnet.x1.xyz

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,11 @@ node_modules/
 dist/
 .idea/
 squads-public-verify/
-/.env
+# Env files (incl. per-network .env.testnet / .env.mainnet / .env.solana-mainnet).
+# These hold secrets (RPC keys, Vercel tokens) and must never be committed.
+.env
+.env.*
+!.env.example
 /.vercel/
+.vercel
+.env*.local

--- a/package.json
+++ b/package.json
@@ -4,8 +4,14 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "dev": "webpack serve --config webpack.dev.js",
-    "build": "webpack --config webpack.prod.js"
+    "dev": "APP_NETWORK=testnet webpack serve --config webpack.dev.js",
+    "dev:testnet": "APP_NETWORK=testnet webpack serve --config webpack.dev.js",
+    "dev:mainnet": "APP_NETWORK=mainnet webpack serve --config webpack.dev.js",
+    "dev:solana-mainnet": "APP_NETWORK=solana-mainnet webpack serve --config webpack.dev.js",
+    "build": "webpack --config webpack.prod.js",
+    "build:testnet": "APP_NETWORK=testnet webpack --config webpack.prod.js",
+    "build:mainnet": "APP_NETWORK=mainnet webpack --config webpack.prod.js",
+    "build:solana-mainnet": "APP_NETWORK=solana-mainnet webpack --config webpack.prod.js"
   },
   "author": "",
   "license": "ISC",

--- a/src/hooks/useSettings.tsx
+++ b/src/hooks/useSettings.tsx
@@ -2,11 +2,27 @@ import * as multisig from '@sqds/multisig';
 // top level
 import { useMutation, useQueryClient, useSuspenseQuery } from '@tanstack/react-query';
 
+// Persisted settings are namespaced by the build's network (APP_NETWORK) so that
+// running locally against different networks (`yarn dev` vs `yarn dev:mainnet`)
+// keeps each network's overrides separate. Without this, an RPC URL or program id
+// saved for one network leaks into another through the shared localhost origin and
+// silently points the app at the wrong chain ("Address does not exist on chain").
+// In production APP_NETWORK is unset, so the keys are unchanged and each network is
+// already isolated by its own origin (multisig.testnet.x1.xyz vs multisig.x1.xyz).
+const NETWORK_SUFFIX = process.env.APP_NETWORK ? `:${process.env.APP_NETWORK}` : '';
+const RPC_URL_KEY = `x-rpc-url${NETWORK_SUFFIX}`;
+const PROGRAM_ID_KEY = `x-program-id-v4${NETWORK_SUFFIX}`;
+const EXPLORER_URL_KEY = `x-explorer-url${NETWORK_SUFFIX}`;
+const STAKE_POOL_PROGRAM_ID_KEY = `x-stake-pool-program-id${NETWORK_SUFFIX}`;
+
+// Exported so non-hook modules (e.g. token metadata) resolve the same key.
+export const RPC_URL_STORAGE_KEY = RPC_URL_KEY;
+
 export const DEFAULT_RPC_URL = process.env.APP_RPC_URL || 'https://rpc.testnet.x1.xyz'; // Default fallback
 
 export const getRpcUrl = () => {
   if (typeof document !== 'undefined') {
-    return localStorage.getItem('x-rpc-url') || DEFAULT_RPC_URL;
+    return localStorage.getItem(RPC_URL_KEY) || DEFAULT_RPC_URL;
   }
   return DEFAULT_RPC_URL;
 };
@@ -21,7 +37,7 @@ export const useRpcUrl = () => {
 
   const setRpcUrl = useMutation({
     mutationFn: (newRpcUrl: string) => {
-      localStorage.setItem(`x-rpc-url`, newRpcUrl);
+      localStorage.setItem(RPC_URL_KEY, newRpcUrl);
       return Promise.resolve(newRpcUrl);
     },
     onSuccess: (newRpcUrl) => {
@@ -37,7 +53,7 @@ const DEFAULT_PROGRAM_ID =
 
 const getProgramId = () => {
   if (typeof window !== 'undefined') {
-    return localStorage.getItem('x-program-id-v4') || DEFAULT_PROGRAM_ID;
+    return localStorage.getItem(PROGRAM_ID_KEY) || DEFAULT_PROGRAM_ID;
   }
   return DEFAULT_PROGRAM_ID;
 };
@@ -52,7 +68,7 @@ export const useProgramId = () => {
 
   const setProgramId = useMutation({
     mutationFn: (newProgramId: string) => {
-      localStorage.setItem('x-program-id-v4', newProgramId);
+      localStorage.setItem(PROGRAM_ID_KEY, newProgramId);
       return Promise.resolve(newProgramId);
     },
     onSuccess: (newProgramId) => {
@@ -66,7 +82,7 @@ export const useProgramId = () => {
 const DEFAULT_EXPLORER_URL = process.env.APP_EXPLORER_URL || 'https://explorer.x1.xyz';
 const getExplorerUrl = () => {
   if (typeof window !== 'undefined') {
-    return localStorage.getItem('x-explorer-url') || DEFAULT_EXPLORER_URL;
+    return localStorage.getItem(EXPLORER_URL_KEY) || DEFAULT_EXPLORER_URL;
   }
   return DEFAULT_PROGRAM_ID;
 };
@@ -81,7 +97,7 @@ export const useExplorerUrl = () => {
 
   const setExplorerUrl = useMutation({
     mutationFn: (newExplorerUrl: string) => {
-      localStorage.setItem('x-explorer-url', newExplorerUrl);
+      localStorage.setItem(EXPLORER_URL_KEY, newExplorerUrl);
       return Promise.resolve(newExplorerUrl);
     },
     onSuccess: (newExplorerUrl) => {
@@ -96,7 +112,7 @@ const DEFAULT_STAKE_POOL_PROGRAM_ID =
   process.env.APP_STAKE_POOL_PROGRAM_ID || 'XPoo1Fx6KNgeAzFcq2dPTo95bWGUSj5KdPVqYj9CZux';
 const getStakePoolProgramId = () => {
   if (typeof window !== 'undefined') {
-    return localStorage.getItem('x-stake-pool-program-id') || DEFAULT_STAKE_POOL_PROGRAM_ID;
+    return localStorage.getItem(STAKE_POOL_PROGRAM_ID_KEY) || DEFAULT_STAKE_POOL_PROGRAM_ID;
   }
   return DEFAULT_STAKE_POOL_PROGRAM_ID;
 };
@@ -111,7 +127,7 @@ export const useStakePoolProgramId = () => {
 
   const setStakePoolProgramId = useMutation({
     mutationFn: (newStakePoolProgramId: string) => {
-      localStorage.setItem('x-stake-pool-program-id', newStakePoolProgramId);
+      localStorage.setItem(STAKE_POOL_PROGRAM_ID_KEY, newStakePoolProgramId);
       return Promise.resolve(newStakePoolProgramId);
     },
     onSuccess: (newStakePoolProgramId) => {

--- a/src/lib/token/tokenMetadata.ts
+++ b/src/lib/token/tokenMetadata.ts
@@ -10,6 +10,7 @@ import {
   getExtensionData,
   Mint,
 } from '@solana/spl-token';
+import { RPC_URL_STORAGE_KEY } from '@/hooks/useSettings';
 import { unpack } from '@solana/spl-token-metadata';
 
 export interface TokenMetadata {
@@ -143,8 +144,8 @@ export async function getTokenMetadata(
     // Always prefer the RPC URL from localStorage over the connection's endpoint
     // because the wallet adapter connection might have a different RPC
     const rpcUrl =
-      typeof window !== 'undefined' && localStorage.getItem('x-rpc-url')
-        ? localStorage.getItem('x-rpc-url')!
+      typeof window !== 'undefined' && localStorage.getItem(RPC_URL_STORAGE_KEY)
+        ? localStorage.getItem(RPC_URL_STORAGE_KEY)!
         : connection.rpcEndpoint;
 
     // First, determine which token program owns this mint

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -4,8 +4,21 @@ const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin');
 const webpack = require('webpack');
 const dotenv = require('dotenv');
 
-// Load .env file
-dotenv.config();
+// Select which env file to load based on APP_NETWORK:
+//   APP_NETWORK=testnet        -> .env.testnet
+//   APP_NETWORK=mainnet        -> .env.mainnet
+//   APP_NETWORK=solana-mainnet -> .env.solana-mainnet
+// When APP_NETWORK is unset (e.g. on Vercel, where APP_* vars come from the
+// project dashboard), fall back to .env. dotenv does NOT override variables that
+// are already present in the environment, so Vercel's dashboard values win.
+const appNetwork = process.env.APP_NETWORK;
+const envFile = appNetwork ? `.env.${appNetwork}` : '.env';
+const dotenvResult = dotenv.config({ path: path.resolve(__dirname, envFile) });
+console.log(
+  dotenvResult.error
+    ? `[webpack] ${envFile} not found; using existing environment variables`
+    : `[webpack] Loaded environment from ${envFile}`
+);
 
 module.exports = {
   entry: './src/index.tsx',
@@ -69,6 +82,9 @@ module.exports = {
       'process.env.APP_RPC_URL': JSON.stringify(process.env.APP_RPC_URL || ''),
       'process.env.APP_PROGRAM_ID': JSON.stringify(process.env.APP_PROGRAM_ID || ''),
       'process.env.APP_EXPLORER_URL': JSON.stringify(process.env.APP_EXPLORER_URL || ''),
+      // Network this build targets (testnet/mainnet/solana-mainnet). Used to
+      // namespace persisted settings so networks don't collide on localhost.
+      'process.env.APP_NETWORK': JSON.stringify(process.env.APP_NETWORK || ''),
       // Pass through all APP_SAVED_SQUAD_ environment variables as a JSON object
       'process.env.APP_SAVED_SQUADS': JSON.stringify(
         Object.keys(process.env)


### PR DESCRIPTION
## Summary

Makes it easy to run the app against **X1 testnet, X1 mainnet, and Solana mainnet** from one local checkout, and fixes a confusing "works in production, fails locally" class of bug caused by `localStorage` settings leaking across networks.

## What changed

**Per-network env files**
- `webpack.common.js` selects the env file from `APP_NETWORK` (`APP_NETWORK=testnet` → `.env.testnet`, etc.). When unset (e.g. Vercel), it falls back to `.env`, and since `dotenv` never overrides existing `process.env`, **Vercel dashboard vars stay authoritative** — production builds are unaffected.
- `package.json` scripts:
  - `yarn dev` (defaults to testnet), `yarn dev:mainnet`, `yarn dev:solana-mainnet`
  - `yarn build:testnet` / `build:mainnet` / `build:solana-mainnet` (bare `yarn build` left untouched for Vercel)
- `.gitignore` now ignores all `.env*` **except** `.env.example`. The per-network files hold secrets (RPC keys, Vercel OIDC tokens) and must never be committed.
- `.env.example` documents the whole scheme.

**Per-network settings namespacing (bug fix)**
- Persisted settings (RPC URL, program id, explorer URL, stake-pool program id) are now keyed by network: `x-rpc-url:${APP_NETWORK}`, etc.
- **Why:** `getRpcUrl()` reads `localStorage` before the env default. Because all local networks share the `localhost` origin, an RPC saved for one network (via Settings) leaked into another and silently pointed the app at the wrong chain — e.g. a testnet multisig showing *"Address does not exist on chain"* because the app was hitting mainnet. Production avoids this only because each network is a separate origin.
- In production `APP_NETWORK` is unset, so keys stay un-suffixed (`x-rpc-url`) — **no behavior change, no reset of existing users' overrides**; origins already isolate them.
- `APP_NETWORK` is injected via `DefinePlugin`; `tokenMetadata.ts` (the one other direct reader) uses the same exported `RPC_URL_STORAGE_KEY`.

## Verification
- `tsc --noEmit` clean on `src/`.
- Confirmed `APP_NETWORK` injection + key derivation for testnet/mainnet/solana-mainnet and the prod (unset → unchanged key) case.
- `yarn build:testnet` compiles green; the built `bundle.js` contains both `x-rpc-url:testnet` and `rpc.testnet.x1.xyz`.

## Test plan
1. Create the local env files (already pulled from Vercel): `.env.testnet`, `.env.mainnet`, `.env.solana-mainnet`.
2. `yarn dev` → DevTools Network shows calls to `rpc.testnet.x1.xyz`; open a testnet multisig (e.g. `/8pJxnT9NDvfZVFWSrXeNUutUeaun9Z8U6qHxPfTk1oBM/config`) → loads.
3. Stop, `yarn dev:mainnet` → calls go to `rpc.mainnet.x1.xyz`; the testnet override from step 2 does **not** leak in.
4. `yarn dev:solana-mainnet` → calls go to the Solana RPC.
5. In Settings on one network, set a custom RPC → confirm it persists for that network only (switch away and back), and does not affect the others.
6. Confirm `git status` never shows `.env.testnet/.env.mainnet/.env.solana-mainnet` as untracked (they're gitignored).

## Notes
- Scripts use a POSIX `APP_NETWORK=… ` prefix (fine on macOS/Linux; Windows would need `cross-env`).
- The old root `.env` (dead `NEXT_PUBLIC_*` vars) is now unused by the default scripts and can be deleted.
- Heads-up for prod: `vercel.json`'s CSP `connect-src` only lists `rpc.testnet.x1.xyz` / `rpc.x1.xyz`; add any other RPC host (e.g. `rpc.mainnet.x1.xyz` or the Solana RPC) on CSP-covered domains or those calls get blocked.