### PR TITLE
fix: treat deactivated genesis stakes as inactive and guard batch unstake

### DIFF
--- a/src/components/staking/StakeAccountActions.tsx
+++ b/src/components/staking/StakeAccountActions.tsx
@@ -59,7 +59,12 @@ export function StakeAccountActions({
 
   const addUnstakeToBatch = () => {
     if (!multisigVault) return;
-    const added = addItem(buildUnstakeBatchItem(account, multisigVault, vaultIndex, label));
+    const item = buildUnstakeBatchItem(account, multisigVault, vaultIndex, label);
+    if (!item) {
+      toast.error('This stake account is already deactivating or inactive');
+      return;
+    }
+    const added = addItem(item);
     if (added) {
       toast.success('Added unstake to batch queue');
     } else {

--- a/src/lib/staking/batchStakeActions.ts
+++ b/src/lib/staking/batchStakeActions.ts
@@ -46,7 +46,15 @@ export function buildUnstakeBatchItem(
   vaultAddress: PublicKey,
   vaultIndex: number,
   label: string
-): NewBatchItem {
+): NewBatchItem | null {
+  // Only active/activating accounts can be deactivated. Re-deactivating an account
+  // that is already deactivating/inactive fails on-chain with StakeError::AlreadyDeactivated
+  // (custom error 0x2) and, because a VaultTransaction executes atomically, reverts the
+  // entire batched proposal. Skip such accounts so they never enter the batch.
+  if (account.state !== 'active' && account.state !== 'activating') {
+    return null;
+  }
+
   return {
     type: 'unstake',
     label: `Unstake ${label}`,

--- a/src/lib/staking/validatorStakeUtils.ts
+++ b/src/lib/staking/validatorStakeUtils.ts
@@ -78,9 +78,17 @@ export async function getStakeAccountsForVault(
 
         const stakeActivation = await getStakeActivation(connection as any, account.pubkey);
 
-        // Handle edge case where activationEpoch is max u64 value
-        // This indicates the stake is actually active from epoch 0
-        if (stake?.delegation?.activationEpoch === '18446744073709551615') {
+        // Genesis/bootstrap stakes report activationEpoch = u64::MAX and are active
+        // from epoch 0. getStakeActivation reports them as inactive, so we correct it —
+        // but ONLY when the stake has not been deactivated. A bootstrap stake with a
+        // real deactivationEpoch has been unstaked, so we trust getStakeActivation
+        // (which correctly reports inactive/deactivating) rather than forcing 'active'.
+        // Forcing 'active' here previously let already-deactivated genesis stakes be
+        // re-deactivated, failing on-chain with StakeError::AlreadyDeactivated (0x2).
+        if (
+          stake?.delegation?.activationEpoch === '18446744073709551615' &&
+          stake?.delegation?.deactivationEpoch === '18446744073709551615'
+        ) {
           stake.delegation.activationEpoch = '0';
           stakeActivation.status = 'active';
           stakeActivation.active = BigInt(stake.delegation.stake);


### PR DESCRIPTION
## Problem

Undelegate proposals can fail permanently with Stake program custom error `0x2` (`StakeError::AlreadyDeactivated`).

Investigating a stuck mainnet proposal (multisig `89Pks…`, vault tx #95) showed it batched 4 `Deactivate` instructions, two of which targeted **genesis/bootstrap stake accounts that were already deactivated** (epoch 145). Re-deactivating an already-deactivated account returns `0x2`, and because `VaultTransactionExecute` is atomic, the whole proposal reverts and can never execute.

### Why they looked active
Genesis/bootstrap stakes have `delegation.activationEpoch === u64::MAX`. `getStakeActivation` reports those as `inactive`, so `getStakeAccountsForVault` overrode their status to `active`. But the override fired on `activationEpoch === u64::MAX` **alone**, ignoring `deactivationEpoch` — so a bootstrap stake that had since been deactivated was still labeled `active` and offered for undelegation.

## Changes
- **`validatorStakeUtils.ts`** — narrow the bootstrap override to require **both** `activationEpoch` and `deactivationEpoch` to be `u64::MAX`; otherwise trust `getStakeActivation` (which correctly returns `inactive`/`deactivating`).
- **`batchStakeActions.ts`** — `buildUnstakeBatchItem` returns `null` for non-active accounts, so already-deactivating/inactive stakes can't enter a batch (defense-in-depth; `Deactivate` is not idempotent on-chain).
- **`StakeAccountActions.tsx`** — handle the `null` with a clear toast.

## Verification
Checked all 4 accounts against X1 mainnet (epoch 292). After the fix:
- `5dJiFDz8`, `EwfDYioH` (genuinely active) → `active`, still offered for undelegate.
- `551SKkXL`, `FbHvLGHc` (deactivated @ epoch 145) → correctly `inactive`, offered for **withdraw** instead of re-deactivate.

`tsc --noEmit` reports no new errors in `src/` (only pre-existing `node_modules` type-conflict noise).

## Note
The originally-stuck proposal #95 is unexecutable and should be closed; the two deactivated accounts just need a withdraw.