### PR TITLE
fix: withdraw stakes minus rent reserve to avoid close during cooldown

### DIFF
--- a/src/components/staking/StakeAccountActions.tsx
+++ b/src/components/staking/StakeAccountActions.tsx
@@ -74,7 +74,14 @@ export function StakeAccountActions({
 
   const addWithdrawToBatch = () => {
     if (!multisigVault) return;
-    const added = addItem(buildWithdrawBatchItem(account, multisigVault, vaultIndex, label));
+    const item = buildWithdrawBatchItem(account, multisigVault, vaultIndex, label);
+    if (!item) {
+      toast.error(
+        'Only fully inactive accounts can be batch-withdrawn. Use the Withdraw dialog for a deactivating account.'
+      );
+      return;
+    }
+    const added = addItem(item);
     if (added) {
       toast.success('Added withdrawal to batch queue');
     } else {
@@ -96,11 +103,11 @@ export function StakeAccountActions({
     if (count === 0) {
       toast.error('Not enough instruction space in batch');
     } else if (count < compatible.length) {
-      toast.warning(`Added ${count} of ${compatible.length} merge operations (instruction limit reached)`);
-    } else {
-      toast.success(
-        `Added ${count} merge operation${count > 1 ? 's' : ''} to batch queue`
+      toast.warning(
+        `Added ${count} of ${compatible.length} merge operations (instruction limit reached)`
       );
+    } else {
+      toast.success(`Added ${count} merge operation${count > 1 ? 's' : ''} to batch queue`);
     }
   };
 
@@ -165,7 +172,7 @@ export function StakeAccountActions({
                   Add Unstake to Batch
                 </DropdownMenuItem>
               )}
-              {canWithdraw && (
+              {account.state === 'inactive' && (
                 <DropdownMenuItem onClick={addWithdrawToBatch} className="cursor-pointer">
                   <Layers className="mr-2 h-4 w-4" />
                   Add Withdraw to Batch

--- a/src/components/staking/StakeAccountActions.tsx
+++ b/src/components/staking/StakeAccountActions.tsx
@@ -163,7 +163,7 @@ export function StakeAccountActions({
           </DropdownMenuItem>
 
           {/* Batch actions */}
-          {(canUndelegate || canWithdraw || canSplit || canMerge) && (
+          {(canUndelegate || account.state === 'inactive' || canSplit || canMerge) && (
             <>
               <DropdownMenuSeparator />
               {canUndelegate && (

--- a/src/components/staking/WithdrawStakeDialog.tsx
+++ b/src/components/staking/WithdrawStakeDialog.tsx
@@ -26,7 +26,11 @@ import { useQueryClient } from '@tanstack/react-query';
 import { useAccess } from '@/hooks/useAccess';
 import { waitForConfirmation } from '@/lib/transactionConfirmation';
 import { addMemoToInstructions } from '@/lib/utils/memoInstruction';
-import { createWithdrawStakeInstruction } from '@/lib/staking/validatorStakeUtils';
+import {
+  createWithdrawStakeInstruction,
+  getDrainWithdrawLamports,
+  rentReserveLamports,
+} from '@/lib/staking/validatorStakeUtils';
 import { StakeAccountInfo as StakeAccountData } from '@/lib/staking/validatorStakeUtils';
 import { useValidatorsMetadata } from '@/hooks/useValidatorMetadata';
 import {
@@ -181,9 +185,7 @@ export function WithdrawStakeDialog({
       if (isClose) {
         lamports = freshBalance; // closes the account (only valid once fully inactive)
       } else {
-        const reserve = BigInt(
-          Math.round(selectedAccountInfo.rentExemptReserve * LAMPORTS_PER_SOL)
-        );
+        const reserve = rentReserveLamports(selectedAccountInfo);
         lamports = freshBalance > reserve ? freshBalance - reserve : BigInt(0);
       }
     } else {
@@ -434,11 +436,7 @@ export function WithdrawStakeDialog({
                         selectedAccountInfo.state === 'inactive' &&
                         selectedAccountInfo.balanceLamports
                       ) {
-                        const reserve = BigInt(
-                          Math.round(selectedAccountInfo.rentExemptReserve * LAMPORTS_PER_SOL)
-                        );
-                        const balance = BigInt(selectedAccountInfo.balanceLamports);
-                        const lamports = balance > reserve ? balance - reserve : BigInt(0);
+                        const lamports = getDrainWithdrawLamports(selectedAccountInfo);
                         const wholeSol = lamports / BigInt(LAMPORTS_PER_SOL);
                         const remainder = lamports % BigInt(LAMPORTS_PER_SOL);
                         // Convert to SOL with full precision: "wholePart.fractionalPart"

--- a/src/components/staking/WithdrawStakeDialog.tsx
+++ b/src/components/staking/WithdrawStakeDialog.tsx
@@ -100,12 +100,13 @@ export function WithdrawStakeDialog({
     const isStaked =
       selectedAccountInfo.state === 'active' || selectedAccountInfo.state === 'activating';
     if (selectedAccountInfo.state === 'inactive') {
-      // Inactive (fully deactivated/undelegated) accounts can withdraw everything
-      // The only valid withdrawal is the full balance (which closes the account)
-      // Partial withdrawals will fail with "insufficient funds" because the remaining
-      // balance would be less than rent-exempt reserve
-      maxWithdrawable = totalBalance;
-      maxWithdrawableWithRent = totalBalance;
+      // Default to withdrawing everything EXCEPT the rent-exempt reserve. That always
+      // succeeds. Withdrawing the full balance closes the account, which the chain only
+      // allows once the deactivation cooldown is fully complete — getStakeActivation
+      // reports a stake `inactive` an epoch or more before the chain will let it close,
+      // so closing too early fails with "insufficient funds" (short by the reserve).
+      maxWithdrawable = Math.max(0, totalBalance - rentReserve);
+      maxWithdrawableWithRent = totalBalance; // full balance (closes the account)
     } else if (selectedAccountInfo.state === 'deactivating') {
       // Deactivating accounts can only withdraw the inactive portion
       const inactiveAmount = selectedAccountInfo.inactiveStake || 0;
@@ -139,14 +140,23 @@ export function WithdrawStakeDialog({
       programId: programId ? new PublicKey(programId) : multisig.PROGRAM_ID,
     })[0];
 
-    // For full withdrawals of inactive accounts, fetch the account balance one more time
-    // to get the most up-to-date value using raw RPC to preserve precision
+    // Determine the exact lamports to withdraw, preserving precision for very large
+    // balances (>2^53 lamports). Two "drain" intents withdraw most/all of the account:
+    //   - close: withdraw the full balance and deallocate the account
+    //   - safe drain: withdraw everything except the rent-exempt reserve. This always
+    //     succeeds, even while a freshly-deactivated stake is still finishing its
+    //     cooldown (when a full close would fail with "insufficient funds").
     let lamports: number | bigint;
-    const isFullWithdrawal = Math.abs(parsedAmount - selectedAccountInfo.balance) < 0.001;
+    const isClose = Math.abs(parsedAmount - selectedAccountInfo.balance) < 0.001;
+    const isSafeDrain =
+      selectedAccountInfo.state === 'inactive' &&
+      !isClose &&
+      Math.abs(parsedAmount - maxWithdrawable) < 0.001;
 
-    if (isFullWithdrawal && selectedAccountInfo.state === 'inactive') {
-      // For very large balances (>9 quadrillion lamports), we need to make a raw RPC call
-      // to get lamports as a string before JavaScript converts it to a Number
+    if (selectedAccountInfo.state === 'inactive' && (isClose || isSafeDrain)) {
+      // Re-fetch the live balance via raw RPC so large values aren't mangled by
+      // JSON.parse converting them to an imprecise Number.
+      let freshBalance = BigInt(selectedAccountInfo.balanceLamports);
       try {
         const response = await fetch(connection.rpcEndpoint, {
           method: 'POST',
@@ -158,43 +168,26 @@ export function WithdrawStakeDialog({
             params: [selectedAccountInfo.address, { encoding: 'base64' }],
           }),
         });
-
-        // Get raw text to avoid JSON.parse converting large numbers
+        // Read raw text to avoid JSON.parse rounding the lamports value.
         const responseText = await response.text();
-        console.log('Raw RPC response (first 500 chars):', responseText.substring(0, 500));
-
-        // Extract lamports value using regex to preserve it as a string
         const lamportsMatch = responseText.match(/"lamports":(\d+)/);
         if (lamportsMatch && lamportsMatch[1]) {
-          const lamportsString = lamportsMatch[1];
-          const lamportsBigInt = BigInt(lamportsString);
-
-          // Check if the value is safe to convert to Number
-          if (lamportsBigInt <= BigInt(Number.MAX_SAFE_INTEGER)) {
-            lamports = Number(lamportsBigInt);
-            console.log('Fresh account lamports (safe to use as Number):', lamports);
-          } else {
-            // For very large values, keep as BigInt to preserve precision
-            // Our createWithdrawStakeInstruction now supports bigint
-            lamports = lamportsBigInt;
-            console.log(
-              'Fresh account lamports (using BigInt for precision):',
-              lamportsString,
-              '→',
-              lamportsBigInt.toString()
-            );
-          }
-        } else {
-          throw new Error('Could not extract lamports from RPC response');
+          freshBalance = BigInt(lamportsMatch[1]);
         }
       } catch (error) {
-        console.error('Failed to fetch lamports via raw RPC, falling back:', error);
-        lamports = selectedAccountInfo.balanceLamports;
+        console.error('Failed to fetch fresh lamports via raw RPC, using cached balance:', error);
+      }
+
+      if (isClose) {
+        lamports = freshBalance; // closes the account (only valid once fully inactive)
+      } else {
+        const reserve = BigInt(
+          Math.round(selectedAccountInfo.rentExemptReserve * LAMPORTS_PER_SOL)
+        );
+        lamports = freshBalance > reserve ? freshBalance - reserve : BigInt(0);
       }
     } else {
-      lamports = isFullWithdrawal
-        ? selectedAccountInfo.balanceLamports
-        : Math.floor(parsedAmount * LAMPORTS_PER_SOL);
+      lamports = Math.floor(parsedAmount * LAMPORTS_PER_SOL);
     }
 
     const withdrawInstruction = createWithdrawStakeInstruction(
@@ -433,12 +426,19 @@ export function WithdrawStakeDialog({
                     variant="outline"
                     size="sm"
                     onClick={() => {
-                      // For inactive accounts, use exact lamports to avoid floating point errors
+                      // For inactive accounts, use exact lamports to avoid floating point
+                      // errors. The default drains everything except the rent-exempt
+                      // reserve (always succeeds); closing the account is the separate
+                      // "Close" action below.
                       if (
                         selectedAccountInfo.state === 'inactive' &&
                         selectedAccountInfo.balanceLamports
                       ) {
-                        const lamports = BigInt(selectedAccountInfo.balanceLamports);
+                        const reserve = BigInt(
+                          Math.round(selectedAccountInfo.rentExemptReserve * LAMPORTS_PER_SOL)
+                        );
+                        const balance = BigInt(selectedAccountInfo.balanceLamports);
+                        const lamports = balance > reserve ? balance - reserve : BigInt(0);
                         const wholeSol = lamports / BigInt(LAMPORTS_PER_SOL);
                         const remainder = lamports % BigInt(LAMPORTS_PER_SOL);
                         // Convert to SOL with full precision: "wholePart.fractionalPart"
@@ -451,7 +451,7 @@ export function WithdrawStakeDialog({
                     className="w-full"
                   >
                     <span className="truncate">
-                      {selectedAccountInfo.state === 'inactive' ? 'Withdraw All & Close' : 'Max'} •{' '}
+                      {selectedAccountInfo.state === 'inactive' ? 'Withdraw All' : 'Max'} •{' '}
                       {formatXNTCompact(maxWithdrawable * LAMPORTS_PER_SOL)}
                     </span>
                   </Button>
@@ -460,7 +460,22 @@ export function WithdrawStakeDialog({
                       <Button
                         variant="outline"
                         size="sm"
-                        onClick={() => setAmount(maxWithdrawableWithRent.toString())}
+                        onClick={() => {
+                          // Close = withdraw the full balance. Use exact lamports for
+                          // inactive accounts to avoid floating point errors.
+                          if (
+                            selectedAccountInfo.state === 'inactive' &&
+                            selectedAccountInfo.balanceLamports
+                          ) {
+                            const lamports = BigInt(selectedAccountInfo.balanceLamports);
+                            const wholeSol = lamports / BigInt(LAMPORTS_PER_SOL);
+                            const remainder = lamports % BigInt(LAMPORTS_PER_SOL);
+                            const fractional = remainder.toString().padStart(9, '0');
+                            setAmount(`${wholeSol}.${fractional}`);
+                          } else {
+                            setAmount(maxWithdrawableWithRent.toString());
+                          }
+                        }}
                         className="w-full"
                       >
                         <span className="truncate">

--- a/src/lib/staking/batchStakeActions.ts
+++ b/src/lib/staking/batchStakeActions.ts
@@ -8,6 +8,7 @@ import {
   createStakeAccountWithSeedInstructions,
   createDelegateStakeInstruction,
   getCompatibleMergeAccounts,
+  getDrainWithdrawLamports,
 } from '@/lib/staking/validatorStakeUtils';
 
 type NewBatchItem = {
@@ -70,6 +71,12 @@ export function buildWithdrawBatchItem(
   vaultIndex: number,
   label: string
 ): NewBatchItem {
+  // Withdraw everything except the rent-exempt reserve rather than the full balance.
+  // Withdrawing the full balance closes the account, which the chain rejects while a
+  // freshly-deactivated stake is still finishing its cooldown (fails with
+  // InsufficientFunds, short by the reserve) — and in an atomic batch that single
+  // failure reverts the whole proposal. Leaving the reserve always succeeds; the tiny
+  // leftover account can be closed later once fully inactive.
   return {
     type: 'withdraw',
     label: `Withdraw ${label}`,
@@ -78,7 +85,7 @@ export function buildWithdrawBatchItem(
       createWithdrawStakeInstruction(
         new PublicKey(account.address),
         vaultAddress,
-        BigInt(account.balanceLamports)
+        getDrainWithdrawLamports(account)
       ),
     ],
     vaultIndex,

--- a/src/lib/staking/batchStakeActions.ts
+++ b/src/lib/staking/batchStakeActions.ts
@@ -70,13 +70,22 @@ export function buildWithdrawBatchItem(
   vaultAddress: PublicKey,
   vaultIndex: number,
   label: string
-): NewBatchItem {
+): NewBatchItem | null {
+  // Only fully inactive accounts can be drained in a batch. A 'deactivating' account
+  // still holds effective (locked) stake, so withdrawing balance - reserve would exceed
+  // its withdrawable (inactive) portion and fail on-chain — and because a VaultTransaction
+  // executes atomically, that single failure reverts the whole proposal. Such partial
+  // withdrawals must go through the single-withdraw dialog, which caps the amount at the
+  // already-cooled-down portion.
+  if (account.state !== 'inactive') {
+    return null;
+  }
+
   // Withdraw everything except the rent-exempt reserve rather than the full balance.
   // Withdrawing the full balance closes the account, which the chain rejects while a
   // freshly-deactivated stake is still finishing its cooldown (fails with
-  // InsufficientFunds, short by the reserve) — and in an atomic batch that single
-  // failure reverts the whole proposal. Leaving the reserve always succeeds; the tiny
-  // leftover account can be closed later once fully inactive.
+  // InsufficientFunds, short by the reserve). Leaving the reserve always succeeds; the
+  // tiny leftover account can be closed later once fully inactive.
   return {
     type: 'withdraw',
     label: `Withdraw ${label}`,

--- a/src/lib/staking/validatorStakeUtils.ts
+++ b/src/lib/staking/validatorStakeUtils.ts
@@ -26,7 +26,7 @@ export async function validateVoteAccount(
     }
 
     if (!accountInfo.owner.equals(VoteProgram.programId)) {
-      return 'This is not a vote account. Please use the validator\'s vote account address, not their identity address.';
+      return "This is not a vote account. Please use the validator's vote account address, not their identity address.";
     }
 
     return null; // Valid vote account
@@ -229,6 +229,33 @@ export function createWithdrawStakeInstruction(
     toPubkey: vaultAddress,
     lamports,
   }).instructions[0];
+}
+
+/** Rent-exempt reserve of a stake account, in lamports. */
+export function rentReserveLamports(account: StakeAccountInfo): bigint {
+  return BigInt(Math.round(account.rentExemptReserve * LAMPORTS_PER_SOL));
+}
+
+/**
+ * Lamports to withdraw when draining an inactive stake account into the vault.
+ *
+ * A *full-balance* withdraw closes the account (removes the rent-exempt reserve
+ * and deallocates it). The on-chain stake program only permits that once the
+ * deactivation cooldown is fully complete. `getStakeActivation` reports a stake
+ * as `inactive` one or more epochs BEFORE the chain will allow the close, so a
+ * full-balance withdraw of a freshly-deactivated stake fails with
+ * `InsufficientFunds` — short by exactly the rent-exempt reserve. In a batched
+ * VaultTransaction (executed atomically) one such failure reverts the entire
+ * proposal.
+ *
+ * To stay safe regardless of cooldown state we withdraw everything EXCEPT the
+ * rent-exempt reserve. This always succeeds; the leftover reserve is a tiny,
+ * rent-exempt empty stake account that can be closed later once fully inactive.
+ */
+export function getDrainWithdrawLamports(account: StakeAccountInfo): bigint {
+  const balance = BigInt(account.balanceLamports);
+  const reserve = rentReserveLamports(account);
+  return balance > reserve ? balance - reserve : BigInt(0);
 }
 
 export async function createSplitStakeInstructions(

--- a/src/lib/staking/validatorStakeUtils.ts
+++ b/src/lib/staking/validatorStakeUtils.ts
@@ -249,8 +249,12 @@ export function rentReserveLamports(account: StakeAccountInfo): bigint {
  * proposal.
  *
  * To stay safe regardless of cooldown state we withdraw everything EXCEPT the
- * rent-exempt reserve. This always succeeds; the leftover reserve is a tiny,
- * rent-exempt empty stake account that can be closed later once fully inactive.
+ * rent-exempt reserve. The leftover reserve is a tiny, rent-exempt empty stake
+ * account that can be closed later once fully inactive.
+ *
+ * Precondition: `account.state === 'inactive'`. A 'deactivating' account still has
+ * effective (locked) stake, so `balance - reserve` would exceed its withdrawable
+ * portion and fail on-chain — callers must not pass one here.
  */
 export function getDrainWithdrawLamports(account: StakeAccountInfo): bigint {
   const balance = BigInt(account.balanceLamports);


### PR DESCRIPTION
## Problem

A batched stake **withdraw/consolidate** proposal failed in simulation with:

```
Program Stake111...111 failed: insufficient funds for instruction
ERROR: An account's balance was too small to complete the instruction
```

The transaction withdrew the **full balance** of each stake account, which *closes* the account. The on-chain stake program only allows closing a stake once its deactivation cooldown is fully complete. `getStakeActivation` reports a freshly-deactivated stake as `status: inactive` an epoch or more **before** the chain will let it close, so the full-balance withdraw fails — short by exactly the **rent-exempt reserve (2,282,880 lamports = 0.00228288 XNT)**.

In the failing proposal, 3 of 6 stakes were deactivated in the immediately-prior epoch; they could be drained down to the reserve but not closed. Because a `VaultTransaction` executes atomically, that one rejection reverted the whole batch.

## Fix

Withdraw everything **except** the rent-exempt reserve instead of the full balance. This always succeeds regardless of cooldown state; the tiny leftover (a rent-exempt empty stake account) can be closed later once fully inactive.

- **`validatorStakeUtils.ts`** — add `getDrainWithdrawLamports(account)` / `rentReserveLamports(account)` (bigint, precision-safe for balances > 2^53).
- **`batchStakeActions.ts`** — `buildWithdrawBatchItem` drains `balance − rentReserve` (never closes → no atomic-batch revert).
- **`WithdrawStakeDialog.tsx`** — inactive accounts now default the "Withdraw All" button to the safe drain (`balance − rentReserve`, precise bigint) and expose a separate **"Close"** button for the full-balance close (mirrors how `deactivating` accounts already work).

## Verification

- `tsc --noEmit` clean for `src/`; prettier clean.
- Simulated all 6 withdraws at `balance − 2,282,880` against X1 mainnet in a single transaction → **OK, 71k CU** (the same accounts that previously failed at full balance).

## Trade-off

The batch now leaves ~0.00228 XNT of rent dust per withdrawn account (accounts aren't closed). They can be closed later via the dialog's "Close" button once fully inactive. This was chosen deliberately so an atomic batch can never revert on an un-closeable account. Closing-when-safe in the batch (e.g. gated on `currentEpoch > deactivationEpoch + 1`) could be added later if desired.
