### PR TITLE
fix: close inactive stake accounts on withdraw instead of stranding rent

### DIFF
--- a/src/components/staking/StakeAccountActions.tsx
+++ b/src/components/staking/StakeAccountActions.tsx
@@ -83,7 +83,7 @@ export function StakeAccountActions({
     }
     const added = addItem(item);
     if (added) {
-      toast.success('Added withdrawal to batch queue');
+      toast.success('Added withdraw & close to batch queue');
     } else {
       toast.error('Not enough instruction space in batch');
     }
@@ -175,7 +175,7 @@ export function StakeAccountActions({
               {account.state === 'inactive' && (
                 <DropdownMenuItem onClick={addWithdrawToBatch} className="cursor-pointer">
                   <Layers className="mr-2 h-4 w-4" />
-                  Add Withdraw to Batch
+                  Add Withdraw &amp; Close to Batch
                 </DropdownMenuItem>
               )}
               {canSplit && (

--- a/src/components/staking/WithdrawStakeDialog.tsx
+++ b/src/components/staking/WithdrawStakeDialog.tsx
@@ -97,15 +97,11 @@ export function WithdrawStakeDialog({
   // - if is_staked && lamports_and_reserve > stake_account.get_lamports() => error
   // - if not full withdrawal && lamports_and_reserve > stake_account.get_lamports() => error
   let maxWithdrawable = 0;
-  let maxWithdrawableWithRent = 0; // Full balance including rent (closes account)
 
   const SAFETY_BUFFER_PERCENT = 0.01; // 1% safety buffer to prevent edge cases
 
   if (selectedAccountInfo) {
     const totalBalance = selectedAccountInfo.balance;
-    const rentReserve = selectedAccountInfo.rentExemptReserve;
-    const isStaked =
-      selectedAccountInfo.state === 'active' || selectedAccountInfo.state === 'activating';
     if (selectedAccountInfo.state === 'inactive') {
       // A fully inactive account can withdraw its ENTIRE balance, which closes the
       // account and reclaims the rent-exempt reserve into the vault in one shot. This
@@ -113,28 +109,32 @@ export function WithdrawStakeDialog({
       // means); the pre-submit simulation verifies it against live chain state before
       // the proposal is created, so a not-yet-cooled account never slips through.
       maxWithdrawable = totalBalance;
-      maxWithdrawableWithRent = totalBalance; // full balance (closes the account)
     } else if (selectedAccountInfo.state === 'deactivating') {
-      // Deactivating accounts can only withdraw the inactive portion
+      // Deactivating accounts can only withdraw the already-cooled inactive portion.
       const inactiveAmount = selectedAccountInfo.inactiveStake || 0;
       const safetyBuffer = inactiveAmount * SAFETY_BUFFER_PERCENT;
       maxWithdrawable = Math.max(0, inactiveAmount - safetyBuffer);
-      // For account closure, can withdraw full inactive amount + rent exempt portion
-      maxWithdrawableWithRent = Math.max(0, inactiveAmount + rentReserve);
     }
   }
 
   const parsedAmount = parseFloat(amount);
 
-  // For display and button click, convert exact lamports to SOL with full precision
-  const maxWithdrawableExact = selectedAccountInfo
-    ? Number(BigInt(selectedAccountInfo.balanceLamports)) / LAMPORTS_PER_SOL
-    : maxWithdrawable;
+  // Exact ceiling for validation and close detection. Only a fully-inactive account
+  // may withdraw its full balance (and thereby close), using exact integer lamports to
+  // avoid float rounding at the close boundary. For every other state the ceiling is
+  // maxWithdrawable (the cooled-down portion) — NOT the full balance.
+  const maxWithdrawableExact =
+    selectedAccountInfo && selectedAccountInfo.state === 'inactive'
+      ? Number(BigInt(selectedAccountInfo.balanceLamports)) / LAMPORTS_PER_SOL
+      : maxWithdrawable;
 
   const isAmountValid =
     !isNaN(parsedAmount) && parsedAmount > 0 && parsedAmount <= maxWithdrawableExact + 0.000000001; // Small tolerance for floating point precision
+  // Closing only happens when a fully-inactive account withdraws its entire balance.
   const isClosingAccount =
-    Math.abs(parsedAmount - maxWithdrawableExact) < 0.000000001 && maxWithdrawableExact > 0;
+    selectedAccountInfo?.state === 'inactive' &&
+    Math.abs(parsedAmount - maxWithdrawableExact) < 0.000000001 &&
+    maxWithdrawableExact > 0;
 
   const withdrawStake = async () => {
     if (!wallet.publicKey || !multisigAddress || !selectedAccountInfo) {
@@ -199,10 +199,14 @@ export function WithdrawStakeDialog({
 
     // Simulate against live chain state before creating the proposal, so a stake
     // that isn't actually closeable yet fails HERE — not as a revert after the
-    // multisig members have already approved it.
-    const simulation = await simulateVaultInstructions(connection, vaultAddress, instructions);
+    // multisig members have already approved it. If the simulation can't run (RPC
+    // hiccup), warn and proceed rather than block a withdrawal that would succeed.
+    const simulation = await simulateVaultInstructions(connection, wallet.publicKey, instructions);
     if (!simulation.ok) {
-      throw describeVaultSimulationError(simulation);
+      if (simulation.simulated) {
+        throw describeVaultSimulationError(simulation);
+      }
+      console.warn('Pre-proposal simulation could not run; proceeding without it:', simulation.error);
     }
 
     const multisigInfo = await multisig.accounts.Multisig.fromAccountAddress(
@@ -457,7 +461,7 @@ export function WithdrawStakeDialog({
               <div className="flex items-center gap-1 text-xs text-red-500">
                 <AlertCircle className="h-3 w-3" />
                 <span>
-                  Max withdrawable: {formatXNTCompact(maxWithdrawableWithRent * LAMPORTS_PER_SOL)}
+                  Max withdrawable: {formatXNTCompact(maxWithdrawableExact * LAMPORTS_PER_SOL)}
                 </span>
               </div>
             )}

--- a/src/components/staking/WithdrawStakeDialog.tsx
+++ b/src/components/staking/WithdrawStakeDialog.tsx
@@ -28,10 +28,13 @@ import { waitForConfirmation } from '@/lib/transactionConfirmation';
 import { addMemoToInstructions } from '@/lib/utils/memoInstruction';
 import {
   createWithdrawStakeInstruction,
-  getDrainWithdrawLamports,
-  rentReserveLamports,
+  getCloseWithdrawLamports,
 } from '@/lib/staking/validatorStakeUtils';
 import { StakeAccountInfo as StakeAccountData } from '@/lib/staking/validatorStakeUtils';
+import {
+  simulateVaultInstructions,
+  describeVaultSimulationError,
+} from '@/lib/transaction/simulateVaultInstructions';
 import { useValidatorsMetadata } from '@/hooks/useValidatorMetadata';
 import {
   Select,
@@ -104,12 +107,12 @@ export function WithdrawStakeDialog({
     const isStaked =
       selectedAccountInfo.state === 'active' || selectedAccountInfo.state === 'activating';
     if (selectedAccountInfo.state === 'inactive') {
-      // Default to withdrawing everything EXCEPT the rent-exempt reserve. That always
-      // succeeds. Withdrawing the full balance closes the account, which the chain only
-      // allows once the deactivation cooldown is fully complete — getStakeActivation
-      // reports a stake `inactive` an epoch or more before the chain will let it close,
-      // so closing too early fails with "insufficient funds" (short by the reserve).
-      maxWithdrawable = Math.max(0, totalBalance - rentReserve);
+      // A fully inactive account can withdraw its ENTIRE balance, which closes the
+      // account and reclaims the rent-exempt reserve into the vault in one shot. This
+      // is valid precisely because the effective stake is 0 (that's what 'inactive'
+      // means); the pre-submit simulation verifies it against live chain state before
+      // the proposal is created, so a not-yet-cooled account never slips through.
+      maxWithdrawable = totalBalance;
       maxWithdrawableWithRent = totalBalance; // full balance (closes the account)
     } else if (selectedAccountInfo.state === 'deactivating') {
       // Deactivating accounts can only withdraw the inactive portion
@@ -144,22 +147,20 @@ export function WithdrawStakeDialog({
       programId: programId ? new PublicKey(programId) : multisig.PROGRAM_ID,
     })[0];
 
-    // Determine the exact lamports to withdraw, preserving precision for very large
-    // balances (>2^53 lamports). Two "drain" intents withdraw most/all of the account:
-    //   - close: withdraw the full balance and deallocate the account
-    //   - safe drain: withdraw everything except the rent-exempt reserve. This always
-    //     succeeds, even while a freshly-deactivated stake is still finishing its
-    //     cooldown (when a full close would fail with "insufficient funds").
+    // Determine the exact lamports to withdraw.
+    //   - close: withdraw the FULL balance, deallocating the account and reclaiming
+    //     the rent-exempt reserve in one shot. The close path is gated on
+    //     `lamports == balance` EXACTLY — an amount even one lamport short is treated
+    //     as a partial withdraw and reverts for leaving < rent reserve — so we re-fetch
+    //     the live balance and use exact integer lamports (never `float * 1e9`).
+    //   - partial: an explicit smaller amount, floored to whole lamports.
     let lamports: number | bigint;
     const isClose = Math.abs(parsedAmount - selectedAccountInfo.balance) < 0.001;
-    const isSafeDrain =
-      selectedAccountInfo.state === 'inactive' &&
-      !isClose &&
-      Math.abs(parsedAmount - maxWithdrawable) < 0.001;
 
-    if (selectedAccountInfo.state === 'inactive' && (isClose || isSafeDrain)) {
+    if (selectedAccountInfo.state === 'inactive' && isClose) {
       // Re-fetch the live balance via raw RPC so large values aren't mangled by
-      // JSON.parse converting them to an imprecise Number.
+      // JSON.parse converting them to an imprecise Number, and so the close amount
+      // matches the on-chain balance exactly.
       let freshBalance = BigInt(selectedAccountInfo.balanceLamports);
       try {
         const response = await fetch(connection.rpcEndpoint, {
@@ -182,12 +183,7 @@ export function WithdrawStakeDialog({
         console.error('Failed to fetch fresh lamports via raw RPC, using cached balance:', error);
       }
 
-      if (isClose) {
-        lamports = freshBalance; // closes the account (only valid once fully inactive)
-      } else {
-        const reserve = rentReserveLamports(selectedAccountInfo);
-        lamports = freshBalance > reserve ? freshBalance - reserve : BigInt(0);
-      }
+      lamports = freshBalance; // closes the account (valid once fully inactive)
     } else {
       lamports = Math.floor(parsedAmount * LAMPORTS_PER_SOL);
     }
@@ -200,6 +196,14 @@ export function WithdrawStakeDialog({
 
     const instructions: TransactionInstruction[] = [withdrawInstruction];
     addMemoToInstructions(instructions, memo, vaultAddress);
+
+    // Simulate against live chain state before creating the proposal, so a stake
+    // that isn't actually closeable yet fails HERE — not as a revert after the
+    // multisig members have already approved it.
+    const simulation = await simulateVaultInstructions(connection, vaultAddress, instructions);
+    if (!simulation.ok) {
+      throw describeVaultSimulationError(simulation);
+    }
 
     const multisigInfo = await multisig.accounts.Multisig.fromAccountAddress(
       // @ts-ignore
@@ -392,10 +396,10 @@ export function WithdrawStakeDialog({
                     <span>Wait for deactivation to complete or account balance too low</span>
                   </div>
                 )}
-                {maxWithdrawableWithRent > maxWithdrawable && (
+                {selectedAccountInfo.state === 'inactive' && (
                   <p className="mt-2 text-xs text-muted-foreground">
-                    💡 Withdraw {formatXNTCompact(maxWithdrawableWithRent * LAMPORTS_PER_SOL)} to
-                    close account
+                    💡 Withdrawing the full balance closes the account and returns the rent
+                    reserve to the vault.
                   </p>
                 )}
               </div>
@@ -416,72 +420,35 @@ export function WithdrawStakeDialog({
                 className="text-lg"
               />
               {selectedAccountInfo && maxWithdrawable > 0 && (
-                <div
-                  className={
-                    maxWithdrawableWithRent > maxWithdrawable &&
-                    selectedAccountInfo.state !== 'deactivating'
-                      ? 'grid grid-cols-2 gap-2'
-                      : ''
-                  }
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => {
+                    // For inactive accounts, set the EXACT full balance (integer lamports,
+                    // no float rounding) so the withdraw closes the account. For a
+                    // deactivating account, only the already-cooled inactive portion is
+                    // withdrawable.
+                    if (
+                      selectedAccountInfo.state === 'inactive' &&
+                      selectedAccountInfo.balanceLamports
+                    ) {
+                      const lamports = getCloseWithdrawLamports(selectedAccountInfo);
+                      const wholeSol = lamports / BigInt(LAMPORTS_PER_SOL);
+                      const remainder = lamports % BigInt(LAMPORTS_PER_SOL);
+                      // Convert to SOL with full precision: "wholePart.fractionalPart"
+                      const fractional = remainder.toString().padStart(9, '0');
+                      setAmount(`${wholeSol}.${fractional}`);
+                    } else {
+                      setAmount(maxWithdrawable.toString());
+                    }
+                  }}
+                  className="w-full"
                 >
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={() => {
-                      // For inactive accounts, use exact lamports to avoid floating point
-                      // errors. The default drains everything except the rent-exempt
-                      // reserve (always succeeds); closing the account is the separate
-                      // "Close" action below.
-                      if (
-                        selectedAccountInfo.state === 'inactive' &&
-                        selectedAccountInfo.balanceLamports
-                      ) {
-                        const lamports = getDrainWithdrawLamports(selectedAccountInfo);
-                        const wholeSol = lamports / BigInt(LAMPORTS_PER_SOL);
-                        const remainder = lamports % BigInt(LAMPORTS_PER_SOL);
-                        // Convert to SOL with full precision: "wholePart.fractionalPart"
-                        const fractional = remainder.toString().padStart(9, '0');
-                        setAmount(`${wholeSol}.${fractional}`);
-                      } else {
-                        setAmount(maxWithdrawable.toString());
-                      }
-                    }}
-                    className="w-full"
-                  >
-                    <span className="truncate">
-                      {selectedAccountInfo.state === 'inactive' ? 'Withdraw All' : 'Max'} •{' '}
-                      {formatXNTCompact(maxWithdrawable * LAMPORTS_PER_SOL)}
-                    </span>
-                  </Button>
-                  {maxWithdrawableWithRent > maxWithdrawable &&
-                    selectedAccountInfo.state !== 'deactivating' && (
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        onClick={() => {
-                          // Close = withdraw the full balance. Use exact lamports for
-                          // inactive accounts to avoid floating point errors.
-                          if (
-                            selectedAccountInfo.state === 'inactive' &&
-                            selectedAccountInfo.balanceLamports
-                          ) {
-                            const lamports = BigInt(selectedAccountInfo.balanceLamports);
-                            const wholeSol = lamports / BigInt(LAMPORTS_PER_SOL);
-                            const remainder = lamports % BigInt(LAMPORTS_PER_SOL);
-                            const fractional = remainder.toString().padStart(9, '0');
-                            setAmount(`${wholeSol}.${fractional}`);
-                          } else {
-                            setAmount(maxWithdrawableWithRent.toString());
-                          }
-                        }}
-                        className="w-full"
-                      >
-                        <span className="truncate">
-                          Close • {formatXNTCompact(maxWithdrawableWithRent * LAMPORTS_PER_SOL)}
-                        </span>
-                      </Button>
-                    )}
-                </div>
+                  <span className="truncate">
+                    {selectedAccountInfo.state === 'inactive' ? 'Withdraw All & Close' : 'Max'} •{' '}
+                    {formatXNTCompact(maxWithdrawable * LAMPORTS_PER_SOL)}
+                  </span>
+                </Button>
               )}
             </div>
 

--- a/src/lib/staking/batchStakeActions.ts
+++ b/src/lib/staking/batchStakeActions.ts
@@ -8,7 +8,8 @@ import {
   createStakeAccountWithSeedInstructions,
   createDelegateStakeInstruction,
   getCompatibleMergeAccounts,
-  getDrainWithdrawLamports,
+  getCloseWithdrawLamports,
+  isStakeCloseable,
 } from '@/lib/staking/validatorStakeUtils';
 
 type NewBatchItem = {
@@ -71,30 +72,31 @@ export function buildWithdrawBatchItem(
   vaultIndex: number,
   label: string
 ): NewBatchItem | null {
-  // Only fully inactive accounts can be drained in a batch. A 'deactivating' account
-  // still holds effective (locked) stake, so withdrawing balance - reserve would exceed
-  // its withdrawable (inactive) portion and fail on-chain — and because a VaultTransaction
-  // executes atomically, that single failure reverts the whole proposal. Such partial
-  // withdrawals must go through the single-withdraw dialog, which caps the amount at the
+  // Only fully inactive accounts can be withdrawn in a batch. A 'deactivating' account
+  // still holds effective (locked) stake, so any withdraw would exceed its withdrawable
+  // (inactive) portion and fail on-chain — and because a VaultTransaction executes
+  // atomically, that single failure reverts the whole proposal. Such partial withdrawals
+  // must go through the single-withdraw dialog, which caps the amount at the
   // already-cooled-down portion.
-  if (account.state !== 'inactive') {
+  if (!isStakeCloseable(account)) {
     return null;
   }
 
-  // Withdraw everything except the rent-exempt reserve rather than the full balance.
-  // Withdrawing the full balance closes the account, which the chain rejects while a
-  // freshly-deactivated stake is still finishing its cooldown (fails with
-  // InsufficientFunds, short by the reserve). Leaving the reserve always succeeds; the
-  // tiny leftover account can be closed later once fully inactive.
+  // Withdraw the FULL balance, which closes the account and reclaims the rent-exempt
+  // reserve into the vault in one shot — no rent stranded, no second signing round to
+  // sweep dust later. This is valid precisely because the account is fully inactive
+  // (effective stake 0); the pre-proposal simulation in submitBatchProposal verifies it
+  // against live chain state before anyone signs, so a not-yet-cooled account can never
+  // slip through and revert the atomic batch after approval.
   return {
     type: 'withdraw',
-    label: `Withdraw ${label}`,
+    label: `Withdraw & Close ${label}`,
     description: `${formatBalance(account.balance)} XNT - ${shortAddress(account.address)}`,
     instructions: [
       createWithdrawStakeInstruction(
         new PublicKey(account.address),
         vaultAddress,
-        getDrainWithdrawLamports(account)
+        getCloseWithdrawLamports(account)
       ),
     ],
     vaultIndex,

--- a/src/lib/staking/validatorStakeUtils.ts
+++ b/src/lib/staking/validatorStakeUtils.ts
@@ -38,7 +38,7 @@ export async function validateVoteAccount(
 export interface StakeAccountInfo {
   address: string;
   balance: number;
-  balanceLamports: number; // Store original lamports to avoid floating point errors
+  balanceLamports: string; // Exact lamports as a string — precise above 2^53, unlike a JS number
   delegated: number;
   state: 'activating' | 'active' | 'deactivating' | 'inactive';
   delegatedValidator?: string;
@@ -47,6 +47,54 @@ export interface StakeAccountInfo {
   rentExemptReserve: number;
   activeStake?: number;
   inactiveStake?: number;
+}
+
+/**
+ * Fetch exact lamports for a set of accounts as strings, keyed by base58 address.
+ *
+ * web3.js returns `lamports` as a JS number, which silently rounds above 2^53
+ * (~9M XNT). We read the raw JSON-RPC response and pull the integer `lamports`
+ * tokens as strings so large balances stay exact — important because a stake
+ * CLOSE must withdraw the balance to the lamport (an off-by-one becomes a
+ * reverting partial withdrawal). `dataSlice` length 0 keeps the response tiny and
+ * ensures the only `"lamports":` token per entry is the account's own balance.
+ */
+async function fetchPreciseLamports(
+  connection: Connection,
+  pubkeys: PublicKey[]
+): Promise<Map<string, string>> {
+  const map = new Map<string, string>();
+  const CHUNK = 100; // getMultipleAccounts caps at 100 addresses per request
+  for (let i = 0; i < pubkeys.length; i += CHUNK) {
+    const chunk = pubkeys.slice(i, i + CHUNK);
+    try {
+      const response = await fetch(connection.rpcEndpoint, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'getMultipleAccounts',
+          params: [
+            chunk.map((p) => p.toBase58()),
+            { encoding: 'base64', dataSlice: { offset: 0, length: 0 } },
+          ],
+        }),
+      });
+      const text = await response.text();
+      const matches = [...text.matchAll(/"lamports":(\d+)/g)];
+      // The value array is in request order with no data payload, so exactly one
+      // lamports token per account. If the count doesn't line up (e.g. a null
+      // account), skip this chunk so we never misalign an amount onto the wrong
+      // account — callers fall back to the (imprecise) parsed value.
+      if (matches.length === chunk.length) {
+        chunk.forEach((p, idx) => map.set(p.toBase58(), matches[idx][1]));
+      }
+    } catch (error) {
+      console.error('Failed to fetch precise lamports; large balances may be imprecise:', error);
+    }
+  }
+  return map;
 }
 
 export async function getStakeAccountsForVault(
@@ -69,6 +117,15 @@ export async function getStakeAccountsForVault(
     // Needed to correctly classify genesis stakes at their deactivation-epoch boundary
     // (see the genesis handling below).
     const { epoch: currentEpoch } = await connection.getEpochInfo();
+
+    // getParsedProgramAccounts returns each account's `lamports` as a JS number, which
+    // rounds above 2^53 (any stake over ~9M XNT). A close withdraws the EXACT balance,
+    // so an off-by-a-lamport amount becomes a reverting partial withdraw. Read the exact
+    // lamports as strings so `balanceLamports` (and the close amount) stays precise.
+    const preciseLamports = await fetchPreciseLamports(
+      connection,
+      accounts.map((a: any) => a.pubkey as PublicKey)
+    );
 
     const stakeAccounts: StakeAccountInfo[] = [];
 
@@ -120,7 +177,8 @@ export async function getStakeAccountsForVault(
         stakeAccounts.push({
           address: account.pubkey.toBase58(),
           balance: account.account.lamports / LAMPORTS_PER_SOL,
-          balanceLamports: account.account.lamports,
+          balanceLamports:
+            preciseLamports.get(account.pubkey.toBase58()) ?? String(account.account.lamports),
           delegated: stake.delegation.stake / LAMPORTS_PER_SOL,
           state: state as 'activating' | 'active' | 'deactivating' | 'inactive',
           delegatedValidator: stake.delegation?.voter,
@@ -143,7 +201,8 @@ export async function getStakeAccountsForVault(
         stakeAccounts.push({
           address: account.pubkey.toBase58(),
           balance: account.account.lamports / LAMPORTS_PER_SOL,
-          balanceLamports: account.account.lamports,
+          balanceLamports:
+            preciseLamports.get(account.pubkey.toBase58()) ?? String(account.account.lamports),
           delegated: delegated,
           state: 'inactive',
           rentExemptReserve: meta.rentExemptReserve / LAMPORTS_PER_SOL,

--- a/src/lib/staking/validatorStakeUtils.ts
+++ b/src/lib/staking/validatorStakeUtils.ts
@@ -107,8 +107,11 @@ export async function getStakeAccountsForVault(
           delegated: stake.delegation.stake / LAMPORTS_PER_SOL,
           state: state as 'activating' | 'active' | 'deactivating' | 'inactive',
           delegatedValidator: stake.delegation?.voter,
-          activationEpoch: stake.activationEpoch,
-          deactivationEpoch: stake.deactivationEpoch,
+          // Epochs live on `stake.delegation`, not `stake` — and are u64 strings
+          // (u64::MAX = "not deactivated"). Parse to numbers so callers can reason
+          // about the deactivation cooldown.
+          activationEpoch: parseEpoch(stake.delegation?.activationEpoch),
+          deactivationEpoch: parseEpoch(stake.delegation?.deactivationEpoch),
           rentExemptReserve: meta.rentExemptReserve / LAMPORTS_PER_SOL,
           activeStake: Number(stakeActivation.active / BigInt(LAMPORTS_PER_SOL)),
           inactiveStake: Number(stakeActivation.inactive / BigInt(LAMPORTS_PER_SOL)),
@@ -236,25 +239,65 @@ export function rentReserveLamports(account: StakeAccountInfo): bigint {
   return BigInt(Math.round(account.rentExemptReserve * LAMPORTS_PER_SOL));
 }
 
+/** u64::MAX — the "not set" sentinel the stake program uses for activation/deactivation epochs. */
+const U64_MAX_STR = '18446744073709551615';
+
+/** Parse a u64 epoch string into a number, treating the u64::MAX sentinel as "unset". */
+function parseEpoch(value: unknown): number | undefined {
+  if (value === undefined || value === null) return undefined;
+  const s = String(value);
+  if (s === U64_MAX_STR) return undefined;
+  const n = Number(s);
+  return Number.isFinite(n) ? n : undefined;
+}
+
 /**
- * Lamports to withdraw when draining an inactive stake account into the vault.
+ * Whether a stake account can be fully closed (withdraw the entire balance and
+ * deallocate) right now.
  *
- * A *full-balance* withdraw closes the account (removes the rent-exempt reserve
- * and deallocates it). The on-chain stake program only permits that once the
- * deactivation cooldown is fully complete. `getStakeActivation` reports a stake
- * as `inactive` one or more epochs BEFORE the chain will allow the close, so a
- * full-balance withdraw of a freshly-deactivated stake fails with
- * `InsufficientFunds` — short by exactly the rent-exempt reserve. In a batched
- * VaultTransaction (executed atomically) one such failure reverts the entire
- * proposal.
+ * The on-chain stake program permits a full-balance close iff the account's
+ * *effective* stake is exactly 0 — i.e. it is fully cooled down. The withdraw
+ * check is `lamports + effective_stake + rent_reserve > balance`, so while any
+ * effective stake remains BOTH a full close AND a `balance - reserve` drain fail
+ * identically. Our `state === 'inactive'` verdict is exactly `effective_stake == 0`
+ * (from `getStakeActivation` / the client-side activation calc), so it is the
+ * correct gate. The residual epoch-boundary race (RPC reporting `inactive` an
+ * epoch early) is caught by the pre-proposal simulation, which runs the real
+ * withdraw against live chain state before anyone signs.
+ */
+export function isStakeCloseable(account: StakeAccountInfo): boolean {
+  return account.state === 'inactive';
+}
+
+/**
+ * Lamports to withdraw to CLOSE an inactive stake account — the full balance,
+ * which deallocates the account and reclaims the rent-exempt reserve into the
+ * vault in a single instruction (no rent left stranded, no second proposal).
  *
- * To stay safe regardless of cooldown state we withdraw everything EXCEPT the
- * rent-exempt reserve. The leftover reserve is a tiny, rent-exempt empty stake
- * account that can be closed later once fully inactive.
+ * Uses exact integer lamports (never `float * 1e9`), because the close path is
+ * gated on `lamports == balance` exactly: an amount even one lamport short is
+ * treated as a partial withdrawal and reverts with `InsufficientFunds` for
+ * leaving less than the rent reserve. An inactive account's balance is stable
+ * (it earns no rewards), so this exact value stays valid through the
+ * sign→execute delay.
  *
- * Precondition: `account.state === 'inactive'`. A 'deactivating' account still has
- * effective (locked) stake, so `balance - reserve` would exceed its withdrawable
- * portion and fail on-chain — callers must not pass one here.
+ * Precondition: `isStakeCloseable(account)` (fully inactive / effective stake 0).
+ */
+export function getCloseWithdrawLamports(account: StakeAccountInfo): bigint {
+  return BigInt(account.balanceLamports);
+}
+
+/**
+ * Lamports to withdraw when draining an inactive stake account WITHOUT closing
+ * it — everything except the rent-exempt reserve. This leaves a tiny rent-exempt
+ * empty account behind and is only a fallback; prefer `getCloseWithdrawLamports`
+ * so the rent is reclaimed in one shot.
+ *
+ * Note: this does NOT survive the deactivation cooldown — a `balance - reserve`
+ * withdraw fails on-chain exactly when a full close does (both require
+ * effective stake 0), so it is not a "safe during cooldown" alternative.
+ *
+ * Precondition: `account.state === 'inactive'`.
  */
 export function getDrainWithdrawLamports(account: StakeAccountInfo): bigint {
   const balance = BigInt(account.balanceLamports);

--- a/src/lib/staking/validatorStakeUtils.ts
+++ b/src/lib/staking/validatorStakeUtils.ts
@@ -66,6 +66,10 @@ export async function getStakeAccountsForVault(
       // Disable JSON parsing to get raw response with string lamports
     })) as any;
 
+    // Needed to correctly classify genesis stakes at their deactivation-epoch boundary
+    // (see the genesis handling below).
+    const { epoch: currentEpoch } = await connection.getEpochInfo();
+
     const stakeAccounts: StakeAccountInfo[] = [];
 
     for (const account of accounts) {
@@ -78,21 +82,34 @@ export async function getStakeAccountsForVault(
 
         const stakeActivation = await getStakeActivation(connection as any, account.pubkey);
 
-        // Genesis/bootstrap stakes report activationEpoch = u64::MAX and are active
-        // from epoch 0. getStakeActivation reports them as inactive, so we correct it —
-        // but ONLY when the stake has not been deactivated. A bootstrap stake with a
-        // real deactivationEpoch has been unstaked, so we trust getStakeActivation
-        // (which correctly reports inactive/deactivating) rather than forcing 'active'.
-        // Forcing 'active' here previously let already-deactivated genesis stakes be
-        // re-deactivated, failing on-chain with StakeError::AlreadyDeactivated (0x2).
-        if (
-          stake?.delegation?.activationEpoch === '18446744073709551615' &&
-          stake?.delegation?.deactivationEpoch === '18446744073709551615'
-        ) {
+        // Genesis/bootstrap stakes report activationEpoch = u64::MAX, which breaks
+        // getStakeActivation's activation math and makes it report them as `inactive`
+        // regardless of their real state. We correct that here.
+        const isGenesisStake = stake?.delegation?.activationEpoch === '18446744073709551615';
+        const deactivationEpochStr = stake?.delegation?.deactivationEpoch;
+        if (isGenesisStake && deactivationEpochStr === '18446744073709551615') {
+          // Not deactivated: a genesis stake is active from epoch 0.
+          // (Forcing 'active' only when NOT deactivated avoids re-deactivating an
+          // already-unstaked genesis stake, which fails with AlreadyDeactivated 0x2.)
           stake.delegation.activationEpoch = '0';
           stakeActivation.status = 'active';
           stakeActivation.active = BigInt(stake.delegation.stake);
           stakeActivation.inactive = BigInt(account.account.lamports) - stakeActivation.active;
+        } else if (
+          isGenesisStake &&
+          deactivationEpochStr &&
+          currentEpoch <= Number(deactivationEpochStr)
+        ) {
+          // Deactivated, but we're still AT (or before) the deactivation epoch: the full
+          // stake is still effective and only cools to 0 at deactivationEpoch + 1, so it
+          // is DEACTIVATING, not inactive. getStakeActivation mis-reports it as inactive
+          // (activationEpoch = u64::MAX), so correct it — otherwise the UI offers a
+          // withdraw/close that the chain would reject (short by the whole stake). Once
+          // currentEpoch > deactivationEpoch the stake has cooled and getStakeActivation's
+          // 'inactive' is correct, so we leave it alone.
+          stakeActivation.status = 'deactivating';
+          stakeActivation.active = BigInt(stake.delegation.stake);
+          stakeActivation.inactive = BigInt(0);
         }
 
         let state = 'inactive';

--- a/src/lib/staking/validatorStakeUtils.ts
+++ b/src/lib/staking/validatorStakeUtils.ts
@@ -234,11 +234,6 @@ export function createWithdrawStakeInstruction(
   }).instructions[0];
 }
 
-/** Rent-exempt reserve of a stake account, in lamports. */
-export function rentReserveLamports(account: StakeAccountInfo): bigint {
-  return BigInt(Math.round(account.rentExemptReserve * LAMPORTS_PER_SOL));
-}
-
 /** u64::MAX — the "not set" sentinel the stake program uses for activation/deactivation epochs. */
 const U64_MAX_STR = '18446744073709551615';
 
@@ -285,24 +280,6 @@ export function isStakeCloseable(account: StakeAccountInfo): boolean {
  */
 export function getCloseWithdrawLamports(account: StakeAccountInfo): bigint {
   return BigInt(account.balanceLamports);
-}
-
-/**
- * Lamports to withdraw when draining an inactive stake account WITHOUT closing
- * it — everything except the rent-exempt reserve. This leaves a tiny rent-exempt
- * empty account behind and is only a fallback; prefer `getCloseWithdrawLamports`
- * so the rent is reclaimed in one shot.
- *
- * Note: this does NOT survive the deactivation cooldown — a `balance - reserve`
- * withdraw fails on-chain exactly when a full close does (both require
- * effective stake 0), so it is not a "safe during cooldown" alternative.
- *
- * Precondition: `account.state === 'inactive'`.
- */
-export function getDrainWithdrawLamports(account: StakeAccountInfo): bigint {
-  const balance = BigInt(account.balanceLamports);
-  const reserve = rentReserveLamports(account);
-  return balance > reserve ? balance - reserve : BigInt(0);
 }
 
 export async function createSplitStakeInstructions(

--- a/src/lib/transaction/batchProposals.ts
+++ b/src/lib/transaction/batchProposals.ts
@@ -73,11 +73,19 @@ export async function submitBatchProposal(
   // A VaultTransaction executes atomically, so a single failing instruction (e.g. a
   // stake that isn't fully cooled down, or a full-balance close whose amount drifted)
   // would revert the whole proposal — after the multisig members already spent their
-  // signatures approving it. Failing here means nothing is submitted and no signatures
-  // are wasted.
-  const simulation = await simulateVaultInstructions(connection, vaultAddress, allInstructions);
+  // signatures approving it. A genuine revert here means nothing is submitted and no
+  // signatures are wasted. If the simulation itself can't run (RPC hiccup), warn and
+  // proceed rather than hard-block a proposal that would otherwise succeed.
+  const simulation = await simulateVaultInstructions(
+    connection,
+    wallet.publicKey,
+    allInstructions
+  );
   if (!simulation.ok) {
-    throw new Error(describeVaultSimulationError(simulation));
+    if (simulation.simulated) {
+      throw new Error(describeVaultSimulationError(simulation));
+    }
+    console.warn('Pre-proposal simulation could not run; proceeding without it:', simulation.error);
   }
 
   const blockhash = (await connection.getLatestBlockhash()).blockhash;

--- a/src/lib/transaction/batchProposals.ts
+++ b/src/lib/transaction/batchProposals.ts
@@ -9,6 +9,10 @@ import {
 import { WalletContextState } from '@solana/wallet-adapter-react';
 import { waitForConfirmation } from '~/lib/transactionConfirmation';
 import { addMemoToInstructions } from '~/lib/utils/memoInstruction';
+import {
+  simulateVaultInstructions,
+  describeVaultSimulationError,
+} from '~/lib/transaction/simulateVaultInstructions';
 
 export interface BatchProposalItem {
   instructions: TransactionInstruction[];
@@ -63,6 +67,17 @@ export async function submitBatchProposal(
 
   if (memo) {
     addMemoToInstructions(allInstructions, memo, vaultAddress);
+  }
+
+  // Simulate the vault's instructions against live chain state BEFORE anyone signs.
+  // A VaultTransaction executes atomically, so a single failing instruction (e.g. a
+  // stake that isn't fully cooled down, or a full-balance close whose amount drifted)
+  // would revert the whole proposal — after the multisig members already spent their
+  // signatures approving it. Failing here means nothing is submitted and no signatures
+  // are wasted.
+  const simulation = await simulateVaultInstructions(connection, vaultAddress, allInstructions);
+  if (!simulation.ok) {
+    throw new Error(describeVaultSimulationError(simulation));
   }
 
   const blockhash = (await connection.getLatestBlockhash()).blockhash;

--- a/src/lib/transaction/simulateVaultInstructions.ts
+++ b/src/lib/transaction/simulateVaultInstructions.ts
@@ -7,34 +7,47 @@ import {
 } from '@solana/web3.js';
 
 export type VaultSimulationResult =
+  // Simulation ran and the instructions succeeded.
   | { ok: true; unitsConsumed?: number }
-  | { ok: false; error: string; logs?: string[] };
+  // Simulation ran and the instructions REVERTED on-chain — this is a real problem
+  // that would also revert the proposal; the caller should block.
+  | { ok: false; simulated: true; error: string; logs?: string[] }
+  // Simulation could not be run at all (network/RPC error, unsupported options).
+  // The caller should NOT hard-block on this — degrade gracefully.
+  | { ok: false; simulated: false; error: string };
 
 /**
- * Simulate a set of instructions AS IF executed by the vault PDA, against live
- * chain state, BEFORE wrapping them in a multisig proposal.
+ * Simulate a set of the vault's inner instructions against live chain state,
+ * BEFORE wrapping them in a multisig proposal.
  *
  * This surfaces on-chain failures (e.g. a stake account that isn't fully cooled
  * down yet, or a full-balance close whose amount drifted) up front — instead of
  * as an atomic VaultTransaction revert AFTER the multisig members have already
  * spent their signatures approving it.
  *
- * The vault PDA can't produce a real signature, so we simulate with
- * `sigVerify: false` and make the vault the fee payer (hence a signer). The
- * runtime honours the `is_signer` flag without verifying the signature, so the
- * stake program's withdraw-authority check passes and the real balance / stake
- * math runs. Executing the inner instructions directly with the vault as
- * authority is equivalent, for these checks, to the Squads `invoke_signed` CPI.
+ * Fee payer is the connected member's wallet — NOT the vault PDA. The vault is
+ * already marked as a signer inside the instructions (the stake withdraw
+ * authority), and with `sigVerify: false` the runtime honours that `is_signer`
+ * flag without a real signature, so the authority check still passes. Using the
+ * (funded) member as fee payer mirrors real execution — where the executing
+ * member pays the fee and the inner instructions run as the vault via Squads'
+ * `invoke_signed` — and avoids falsely failing when the vault holds little or no
+ * native SOL (common when it has staked its whole balance).
+ *
+ * The result distinguishes a genuine simulated revert (`simulated: true` → the
+ * caller should block) from an inability to simulate (`simulated: false` → the
+ * caller should warn but proceed, so a transient RPC hiccup can't hard-block a
+ * withdrawal that would otherwise succeed).
  */
 export async function simulateVaultInstructions(
   connection: Connection,
-  vaultAddress: PublicKey,
+  feePayer: PublicKey,
   instructions: TransactionInstruction[]
 ): Promise<VaultSimulationResult> {
   try {
     const { blockhash } = await connection.getLatestBlockhash();
     const message = new TransactionMessage({
-      payerKey: vaultAddress,
+      payerKey: feePayer,
       recentBlockhash: blockhash,
       instructions,
     }).compileToV0Message();
@@ -49,29 +62,47 @@ export async function simulateVaultInstructions(
     if (value.err) {
       return {
         ok: false,
+        simulated: true,
         error: typeof value.err === 'string' ? value.err : JSON.stringify(value.err),
         logs: value.logs ?? undefined,
       };
     }
     return { ok: true, unitsConsumed: value.unitsConsumed };
   } catch (e: any) {
-    return { ok: false, error: e?.message || String(e) };
+    // Could not run the simulation (network/RPC error). Don't treat this as a
+    // definitive failure — the caller decides whether to proceed.
+    return { ok: false, simulated: false, error: e?.message || String(e) };
   }
 }
 
 /**
- * Turn a failed vault simulation into an actionable, user-facing message.
- * `InsufficientFunds` here almost always means a stake account isn't fully
- * cooled down (still has effective stake) — the one case where withdraw/close
- * reverts once the account is otherwise inactive.
+ * Turn a genuine simulated revert into an actionable, user-facing message.
+ * Only call this for `simulated: true` results.
+ *
+ * A fee-payer shortfall (the connected member's wallet can't cover the fee)
+ * also contains "insufficient" but is unrelated to the stake, so it is matched
+ * FIRST — otherwise it would be mislabeled as a cooldown problem.
+ *
+ * An `InsufficientFunds` from the stake withdraw itself has two causes, and we
+ * can't always tell them apart from the logs, so the message names both instead
+ * of asserting cooldown (waiting an epoch does nothing for the second case):
+ *   1. the stake isn't fully cooled down yet (still has effective stake), or
+ *   2. the amount is just under the full balance, so the withdraw would leave
+ *      the account below its rent-exempt reserve.
  */
 export function describeVaultSimulationError(result: {
   error: string;
   logs?: string[];
 }): string {
   const haystack = `${result.error} ${(result.logs || []).join(' ')}`.toLowerCase();
+  // Fee-payer funding shortfall (a top-level TransactionError, not the stake
+  // instruction). `InsufficientFundsForFee` contains "insufficient", so it must be
+  // checked before the stake-specific branch below.
+  if (haystack.includes('insufficientfundsforfee') || haystack.includes('funds for fee')) {
+    return 'Simulation failed: the connected wallet does not have enough SOL to cover the transaction fee. Fund the wallet and try again.';
+  }
   if (haystack.includes('insufficient')) {
-    return 'Simulation failed: a stake account is not fully cooled down yet (still has active stake), so it cannot be withdrawn or closed. Wait until it is fully inactive (about one more epoch) and try again.';
+    return 'Simulation failed: the stake withdrawal would leave the account below its rent-exempt reserve. Either the stake is not fully cooled down yet (wait until it is fully inactive, about one more epoch), or the amount is just under the full balance — withdraw the full balance to close the account, or a smaller amount to leave the reserve intact.';
   }
   return `Simulation failed before signing: ${result.error}. Nothing was submitted.`;
 }

--- a/src/lib/transaction/simulateVaultInstructions.ts
+++ b/src/lib/transaction/simulateVaultInstructions.ts
@@ -1,0 +1,77 @@
+import {
+  Connection,
+  PublicKey,
+  TransactionInstruction,
+  TransactionMessage,
+  VersionedTransaction,
+} from '@solana/web3.js';
+
+export type VaultSimulationResult =
+  | { ok: true; unitsConsumed?: number }
+  | { ok: false; error: string; logs?: string[] };
+
+/**
+ * Simulate a set of instructions AS IF executed by the vault PDA, against live
+ * chain state, BEFORE wrapping them in a multisig proposal.
+ *
+ * This surfaces on-chain failures (e.g. a stake account that isn't fully cooled
+ * down yet, or a full-balance close whose amount drifted) up front — instead of
+ * as an atomic VaultTransaction revert AFTER the multisig members have already
+ * spent their signatures approving it.
+ *
+ * The vault PDA can't produce a real signature, so we simulate with
+ * `sigVerify: false` and make the vault the fee payer (hence a signer). The
+ * runtime honours the `is_signer` flag without verifying the signature, so the
+ * stake program's withdraw-authority check passes and the real balance / stake
+ * math runs. Executing the inner instructions directly with the vault as
+ * authority is equivalent, for these checks, to the Squads `invoke_signed` CPI.
+ */
+export async function simulateVaultInstructions(
+  connection: Connection,
+  vaultAddress: PublicKey,
+  instructions: TransactionInstruction[]
+): Promise<VaultSimulationResult> {
+  try {
+    const { blockhash } = await connection.getLatestBlockhash();
+    const message = new TransactionMessage({
+      payerKey: vaultAddress,
+      recentBlockhash: blockhash,
+      instructions,
+    }).compileToV0Message();
+    const tx = new VersionedTransaction(message);
+
+    const { value } = await connection.simulateTransaction(tx, {
+      sigVerify: false,
+      replaceRecentBlockhash: true,
+      commitment: 'confirmed',
+    });
+
+    if (value.err) {
+      return {
+        ok: false,
+        error: typeof value.err === 'string' ? value.err : JSON.stringify(value.err),
+        logs: value.logs ?? undefined,
+      };
+    }
+    return { ok: true, unitsConsumed: value.unitsConsumed };
+  } catch (e: any) {
+    return { ok: false, error: e?.message || String(e) };
+  }
+}
+
+/**
+ * Turn a failed vault simulation into an actionable, user-facing message.
+ * `InsufficientFunds` here almost always means a stake account isn't fully
+ * cooled down (still has effective stake) — the one case where withdraw/close
+ * reverts once the account is otherwise inactive.
+ */
+export function describeVaultSimulationError(result: {
+  error: string;
+  logs?: string[];
+}): string {
+  const haystack = `${result.error} ${(result.logs || []).join(' ')}`.toLowerCase();
+  if (haystack.includes('insufficient')) {
+    return 'Simulation failed: a stake account is not fully cooled down yet (still has active stake), so it cannot be withdrawn or closed. Wait until it is fully inactive (about one more epoch) and try again.';
+  }
+  return `Simulation failed before signing: ${result.error}. Nothing was submitted.`;
+}


### PR DESCRIPTION
## Summary

Withdrawing from an inactive stake account now **closes the account and reclaims the rent-exempt reserve in a single proposal**, instead of draining everything *except* the reserve and leaving a dust account behind. This corrects the approach taken in #16.

## Why the previous approach was wrong

The on-chain stake `Withdraw` closes/deallocates an account only when its **effective stake is 0**. The check is:

```
lamports + effective_stake + rent_reserve > balance  → InsufficientFunds
```

So while a stake is still cooling down, a full close **and** a `balance − reserve` drain fail *identically* — the drain never provided any "safe during cooldown" protection. It only ever differed from a close once the account was already fully inactive, in which case a close would have worked too. Net effect of #16: ~0.00228 XNT of rent stranded on every withdraw, requiring a **second multisig signing round** to reclaim it.

The real `InsufficientFunds`-by-exactly-the-reserve failure was an amount one lamport under the exact balance (rounded / stale cache), which turns a close into a *partial* withdraw that leaves less than the rent reserve. Verified against X1 mainnet: full-balance close on a real leftover account simulates `err: null`; one lamport short reproduces *"An account's balance was too small."*

## Changes

- **Close by default.** Single dialog ("Withdraw All & Close") and batch ("Withdraw & Close") withdraw the **full balance** for inactive accounts, using exact BigInt lamports (never `float × 1e9`) so the close-amount == balance requirement holds. `getCloseWithdrawLamports` + `isStakeCloseable` added; `getDrainWithdrawLamports` kept as a documented fallback.
- **Pre-sign simulation** (`simulateVaultInstructions`). Before a proposal is created, the vault's instructions are simulated against live chain state (vault PDA marked signer, `sigVerify:false`, `replaceRecentBlockhash:true`). A not-yet-cooled account fails **here** with an actionable message — never as an atomic VaultTransaction revert *after* members have already approved it. Wired into both the batch flow and the single-withdraw dialog.
- Fixed `deactivationEpoch`/`activationEpoch` mapping (read from `stake.delegation.*`, parse the u64::MAX sentinel).
- Reserve-only dust accounts left behind by #16 are now closeable directly (the old `maxWithdrawable > 0` gate no longer blocks them).

## Verification

- Live X1 mainnet simulation: full-balance close of a real leftover account → success (~8.8k CU); 1-lamport-short → the exact `InsufficientFunds` the pre-sign sim now catches.
- `tsc` clean on all changed files; production build passes.