### PR TITLE
fix: silently reconnect wallet on tab focus after lock

### DIFF
--- a/src/components/Wallet.tsx
+++ b/src/components/Wallet.tsx
@@ -5,11 +5,19 @@ import { WalletModalProvider } from '@solana/wallet-adapter-react-ui';
 import { WalletError } from '@solana/wallet-adapter-base';
 import { TorusWalletAdapter, LedgerWalletAdapter } from '@solana/wallet-adapter-wallets';
 import { getRpcUrl } from '@/hooks/useSettings';
+import { useWalletAutoReconnect } from '@/hooks/useWalletAutoReconnect';
 
 import '@solana/wallet-adapter-react-ui/styles.css';
 
 type Props = {
   children?: React.ReactNode;
+};
+
+// Runs the silent reconnect-on-focus logic. Must live inside WalletProvider so
+// it can read the wallet context; rendering it here keeps Wallet's tree intact.
+const AutoReconnect: FC<{ children: React.ReactNode }> = ({ children }) => {
+  useWalletAutoReconnect();
+  return <>{children}</>;
 };
 
 export const Wallet: FC<Props> = ({ children }) => {
@@ -38,7 +46,9 @@ export const Wallet: FC<Props> = ({ children }) => {
   return (
     <ConnectionProvider endpoint={endpoint}>
       <WalletProvider wallets={wallets} onError={onError} autoConnect>
-        <WalletModalProvider>{children}</WalletModalProvider>
+        <WalletModalProvider>
+          <AutoReconnect>{children}</AutoReconnect>
+        </WalletModalProvider>
       </WalletProvider>
     </ConnectionProvider>
   );

--- a/src/hooks/useWalletAutoReconnect.ts
+++ b/src/hooks/useWalletAutoReconnect.ts
@@ -1,0 +1,80 @@
+import { useEffect, useRef } from 'react';
+import { useWallet } from '@solana/wallet-adapter-react';
+import { WalletReadyState } from '@solana/wallet-adapter-base';
+import { LedgerWalletName, TorusWalletName } from '@solana/wallet-adapter-wallets';
+
+// Legacy adapters whose `autoConnect()` falls back to a full `connect()` — i.e.
+// it can pop an approval / hardware-device prompt. We must NOT silently re-fire
+// those on tab focus or users would get surprise popups. Standard-Wallet
+// adapters (Phantom, Solflare, Backpack, X1, …) override `autoConnect()` to
+// connect with `{ silent: true }`, which reconnects only if the site is already
+// trusted and otherwise no-ops — safe to fire freely.
+const NON_SILENT_ADAPTERS = new Set<string>([LedgerWalletName, TorusWalletName]);
+
+/**
+ * Re-establishes a dropped wallet connection when the user returns to the tab.
+ *
+ * `WalletProvider`'s built-in `autoConnect` only runs once per mounted adapter
+ * (its attempt flag resets only when the selected wallet changes, not on
+ * disconnect). So if the wallet locks — or the tab is discarded/reloaded while
+ * the wallet is locked — and is later unlocked, nothing re-links it: the user is
+ * stranded on the Connect button until they click it.
+ *
+ * This hook watches for the tab regaining focus/visibility and, if a previously
+ * selected wallet is sitting disconnected, retries the *silent* connect path.
+ * Because it uses `adapter.autoConnect()` (trusted-only), it can never surface a
+ * popup: it either reconnects invisibly or does nothing. Worst case is identical
+ * to today's behavior, so it is safe to ship even where the bug can't be
+ * reproduced.
+ *
+ * Must be rendered inside `<WalletProvider>`.
+ */
+export function useWalletAutoReconnect(): void {
+  const { wallet, connected, connecting } = useWallet();
+  // Guards against overlapping attempts when `focus` and `visibilitychange`
+  // fire back-to-back (they usually do when switching back to the tab).
+  const attemptingRef = useRef(false);
+
+  useEffect(() => {
+    // Nothing selected, already connected, or a connect is already in flight —
+    // nothing to recover.
+    if (!wallet || connected || connecting) return;
+
+    const { adapter } = wallet;
+    // Skip adapters whose silent path isn't actually silent (see above).
+    if (NON_SILENT_ADAPTERS.has(adapter.name)) return;
+
+    const tryReconnect = async () => {
+      if (attemptingRef.current) return;
+      // Only act when the tab is actually in the foreground and the wallet is
+      // detected. A silent connect against a locked/absent wallet just rejects,
+      // so there's nothing to gain by attempting it here.
+      if (typeof document !== 'undefined' && document.visibilityState !== 'visible') return;
+      if (adapter.connected) return;
+      const { readyState } = adapter;
+      if (readyState !== WalletReadyState.Installed && readyState !== WalletReadyState.Loadable) return;
+
+      attemptingRef.current = true;
+      try {
+        await adapter.autoConnect();
+      } catch {
+        // Trusted-only connect failed (wallet still locked, trust revoked, …).
+        // Expected — leave the user on the Connect button, exactly as before.
+      } finally {
+        attemptingRef.current = false;
+      }
+    };
+
+    const onVisibility = () => {
+      if (document.visibilityState === 'visible') void tryReconnect();
+    };
+    const onFocus = () => void tryReconnect();
+
+    window.addEventListener('focus', onFocus);
+    document.addEventListener('visibilitychange', onVisibility);
+    return () => {
+      window.removeEventListener('focus', onFocus);
+      document.removeEventListener('visibilitychange', onVisibility);
+    };
+  }, [wallet, connected, connecting]);
+}


### PR DESCRIPTION
## Problem

Users report having to click **Connect** again after their wallet locks or after being away from the page (both Phantom and X1). The app *does* already cache the selected wallet (`walletName` in localStorage + `autoConnect`), which is why a fresh page load reconnects without touching the button.

The gap: `WalletProvider`'s `autoConnect` is **one-shot per mounted adapter** — its attempt flag only resets when the *selected wallet changes*, not on disconnect. So when the wallet locks (or the tab is discarded/reloaded by the browser while the wallet is locked) and is later unlocked, nothing re-links it. The user is stranded on the Connect button.

## Fix

Add `useWalletAutoReconnect()`, mounted inside `WalletProvider`. When the tab regains focus/visibility and a previously-selected wallet is sitting disconnected, it retries the **trusted-only silent** connect path (`adapter.autoConnect()`, the `{ silent: true }` variant).

By construction this **cannot surface an approval popup**:
- reconnects invisibly if the site is already trusted and the wallet is unlocked, or
- silently no-ops otherwise (still locked, trust revoked, wallet not detected).

Worst case is identical to current behavior — the user lands on the Connect button exactly as before — so there is no regression surface.

**Legacy Ledger/Torus adapters are excluded**: their `autoConnect()` falls back to a full `connect()` that can prompt (device/popup), which is exactly the spam we want to avoid. Every Wallet-Standard wallet (Phantom, Solflare, Backpack, X1) is covered.

## Notes / limitations

- Trigger is tab focus/`visibilitychange`. If a user unlocks the wallet while the app tab is already focused and never blurred, no event fires and it won't auto-reconnect in that narrow sub-case; the dominant "came back to the page" flow is covered.
- No new type errors (0 added over the existing baseline). Project has no test harness, so this was verified by typecheck + reading the adapter source; live confirmation is best done by a reporter who can reproduce the lock/unlock case.

## Test plan

1. Connect Phantom, then lock it (or set a short auto-lock) and hard-reload while locked — reload lands on Connect.
2. Unlock the wallet and switch back to the tab → app reconnects silently, no popup.