### PR TITLE
feat: decode and summarize delegation program instructions

### DIFF
--- a/src/components/instructions/summaries/delegation/AuthoritySummaries.tsx
+++ b/src/components/instructions/summaries/delegation/AuthoritySummaries.tsx
@@ -1,0 +1,165 @@
+import React from 'react';
+import { PublicKey } from '@solana/web3.js';
+import { InstructionSummaryProps } from '@/lib/instructions/types';
+import { AddressWithButtons } from '@/components/AddressWithButtons';
+import { DelegationConfigAccount } from '@/lib/delegation/accounts';
+import { DetailBlock, Field, SummaryShell, Tone, accountByName } from './shared';
+import { useDelegationConfig } from './hooks';
+
+const SYSTEM_PROGRAM = '11111111111111111111111111111111';
+
+function readPubkey(value: unknown): string | undefined {
+  if (!value) return undefined;
+  if (value instanceof PublicKey) return value.toBase58();
+  if (typeof value === 'string') return value;
+  try {
+    return new PublicKey(value as any).toBase58();
+  } catch {
+    return undefined;
+  }
+}
+
+/** An all-zero pubkey means the role is unset rather than assigned. */
+function isUnset(address?: string): boolean {
+  return !address || address === SYSTEM_PROGRAM;
+}
+
+interface AuthorityChangeProps extends InstructionSummaryProps {
+  icon: string;
+  title: string;
+  /** Human name for the role being reassigned. */
+  role: string;
+  /** What the role is allowed to do, shown as a hint. */
+  roleDescription: string;
+  /** Instruction argument holding the new authority. */
+  argKey: string;
+  /** Field on `DelegationConfig` holding the current authority. */
+  configKey: keyof DelegationConfigAccount & string;
+  tone: Tone;
+}
+
+/**
+ * Shared body for the authority-reassignment instructions. Each one hands a
+ * privileged role to a new key, so the summary leads with the current holder.
+ */
+const AuthorityChangeSummary: React.FC<AuthorityChangeProps> = ({
+  instruction,
+  connection,
+  icon,
+  title,
+  role,
+  roleDescription,
+  argKey,
+  configKey,
+  tone,
+}) => {
+  const { config, loading } = useDelegationConfig(instruction, connection);
+
+  const newAuthority = readPubkey(instruction.args?.[argKey]);
+  const currentAuthority = readPubkey(config?.[configKey]);
+  const signer = accountByName(instruction, 'authority', 1);
+  const isNoop = Boolean(newAuthority && currentAuthority && newAuthority === currentAuthority);
+
+  const subtitle = loading
+    ? `Reassigns the ${role} role…`
+    : isNoop
+      ? `Already the ${role} — this proposal changes nothing`
+      : isUnset(currentAuthority) && config
+        ? `Assigns the ${role} role, which is currently unset`
+        : `Hands the ${role} role to a new key`;
+
+  return (
+    <SummaryShell icon={icon} title={title} subtitle={subtitle} tone={isNoop ? 'gray' : tone}>
+      <DetailBlock>
+        {config && (
+          <Field
+            label={`Current ${role}`}
+            value={
+              isUnset(currentAuthority) ? (
+                <span className="text-muted-foreground">Unset</span>
+              ) : (
+                <span className="break-all text-xs">{currentAuthority}</span>
+              )
+            }
+          />
+        )}
+        {newAuthority && <AddressWithButtons address={newAuthority} label={`New ${role}`} />}
+        <div className="text-xs text-muted-foreground">{roleDescription}</div>
+        {signer && <AddressWithButtons address={signer} label="Signer" />}
+      </DetailBlock>
+    </SummaryShell>
+  );
+};
+
+/** `transfer_authority` — hands over full admin control of the program. */
+export const DelegationTransferAuthoritySummary: React.FC<InstructionSummaryProps> = (props) => (
+  <AuthorityChangeSummary
+    {...props}
+    icon="🔑"
+    title="Transfer Admin Authority"
+    role="admin authority"
+    roleDescription="The admin can change every config parameter, approve or reject validators, and reassign these roles. Transferring it is irreversible without the new key's cooperation."
+    argKey="new_authority"
+    configKey="authority"
+    tone="red"
+  />
+);
+
+/** `update_bot_authority` — sets the key the delegation bot signs with. */
+export const DelegationUpdateBotAuthoritySummary: React.FC<InstructionSummaryProps> = (props) => (
+  <AuthorityChangeSummary
+    {...props}
+    icon="🤖"
+    title="Update Bot Authority"
+    role="bot authority"
+    roleDescription="The bot authority records validator criteria and drives the per-epoch stake changes. It cannot change config parameters or validator statuses."
+    argKey="new_bot_authority"
+    configKey="bot_authority"
+    tone="purple"
+  />
+);
+
+/** `update_reviewer_authority` — sets the key allowed to change validator statuses. */
+export const DelegationUpdateReviewerAuthoritySummary: React.FC<InstructionSummaryProps> = (
+  props
+) => (
+  <AuthorityChangeSummary
+    {...props}
+    icon="🧑‍⚖️"
+    title="Update Reviewer Authority"
+    role="reviewer authority"
+    roleDescription="The reviewer can approve, reject and change validator statuses alongside the admin. Setting it to the system program address disables the role."
+    argKey="new_reviewer_authority"
+    configKey="reviewer_authority"
+    tone="blue"
+  />
+);
+
+/**
+ * `initialize_config` — one-time creation of the global config PDA with its
+ * default parameters and initial admin/bot authorities.
+ */
+export const DelegationInitializeConfigSummary: React.FC<InstructionSummaryProps> = ({
+  instruction,
+}) => {
+  const adminAuthority = readPubkey(instruction.args?.admin_authority);
+  const botAuthority = readPubkey(instruction.args?.bot_authority);
+  const config = accountByName(instruction, 'config', 0);
+  const payer = accountByName(instruction, 'payer', 1);
+
+  return (
+    <SummaryShell
+      icon="🚀"
+      title="Initialize Delegation Config"
+      subtitle="Creates the program's global config with default parameters — run once per deployment"
+      tone="purple"
+    >
+      <DetailBlock>
+        {config && <AddressWithButtons address={config} label="Config" />}
+        {adminAuthority && <AddressWithButtons address={adminAuthority} label="Admin" />}
+        {botAuthority && <AddressWithButtons address={botAuthority} label="Bot" />}
+        {payer && <AddressWithButtons address={payer} label="Payer" />}
+      </DetailBlock>
+    </SummaryShell>
+  );
+};

--- a/src/components/instructions/summaries/delegation/ClusterSummaries.tsx
+++ b/src/components/instructions/summaries/delegation/ClusterSummaries.tsx
@@ -1,0 +1,220 @@
+import React from 'react';
+import { InstructionSummaryProps } from '@/lib/instructions/types';
+import { AddressWithButtons } from '@/components/AddressWithButtons';
+import { toNumber } from '@/lib/delegation/values';
+import { DetailBlock, Field, SummaryShell, ValueChange, accountByName } from './shared';
+import { useDelegationClusterInfo } from './hooks';
+
+/** Rows shared by the cluster instructions: the tracked epoch and lock state. */
+const ClusterState: React.FC<{ lastEpoch: number | null; lockedUntilSlot: number | null }> = ({
+  lastEpoch,
+  lockedUntilSlot,
+}) => (
+  <>
+    {lastEpoch !== null && (
+      <Field
+        label="Last processed epoch"
+        value={lastEpoch.toLocaleString()}
+        hint="The bot skips any epoch at or below this number"
+      />
+    )}
+    {lockedUntilSlot !== null && (
+      <Field
+        label="Lock held until slot"
+        value={lockedUntilSlot === 0 ? 'Not locked' : lockedUntilSlot.toLocaleString()}
+        tone={lockedUntilSlot === 0 ? undefined : 'amber'}
+      />
+    )}
+  </>
+);
+
+/** `initialize_cluster_info` — one-time creation of the cluster tracking account. */
+export const DelegationInitializeClusterInfoSummary: React.FC<InstructionSummaryProps> = ({
+  instruction,
+}) => {
+  const clusterInfo = accountByName(instruction, 'cluster_info', 0);
+  const payer = accountByName(instruction, 'payer', 1);
+
+  return (
+    <SummaryShell
+      icon="🌐"
+      title="Initialize Cluster Info"
+      subtitle="Creates the account that tracks epoch processing and the bot's run lock — run once per deployment"
+      tone="purple"
+    >
+      <DetailBlock>
+        {clusterInfo && <AddressWithButtons address={clusterInfo} label="Cluster" />}
+        {payer && <AddressWithButtons address={payer} label="Payer" />}
+      </DetailBlock>
+    </SummaryShell>
+  );
+};
+
+/** `update_cluster_info` — bot marks the current epoch as processed. */
+export const DelegationUpdateClusterInfoSummary: React.FC<InstructionSummaryProps> = ({
+  instruction,
+  connection,
+}) => {
+  const { clusterInfo } = useDelegationClusterInfo(instruction, connection);
+  const bot = accountByName(instruction, 'bot', 2);
+
+  return (
+    <SummaryShell
+      icon="✔️"
+      title="Update Cluster Info"
+      subtitle="Marks the current epoch as fully processed by the delegation bot"
+      tone="gray"
+    >
+      <DetailBlock>
+        <ClusterState
+          lastEpoch={clusterInfo ? toNumber(clusterInfo.last_updated_epoch) : null}
+          lockedUntilSlot={null}
+        />
+        {bot && <AddressWithButtons address={bot} label="Bot" />}
+      </DetailBlock>
+    </SummaryShell>
+  );
+};
+
+/**
+ * `set_cluster_epoch` — admin override of the last-processed epoch, used to
+ * re-run or skip an epoch.
+ */
+export const DelegationSetClusterEpochSummary: React.FC<InstructionSummaryProps> = ({
+  instruction,
+  connection,
+}) => {
+  const { clusterInfo } = useDelegationClusterInfo(instruction, connection);
+  const admin = accountByName(instruction, 'admin', 2);
+
+  const newEpoch = toNumber(instruction.args?.epoch);
+  const currentEpoch = clusterInfo ? toNumber(clusterInfo.last_updated_epoch) : null;
+  const changed = currentEpoch !== null && newEpoch !== null && currentEpoch !== newEpoch;
+  const rewinding = changed && newEpoch! < currentEpoch!;
+
+  return (
+    <SummaryShell
+      icon="⏭️"
+      title="Set Cluster Epoch"
+      subtitle={
+        rewinding
+          ? 'Rewinds the last-processed epoch, letting the bot re-run epochs it already handled'
+          : 'Overrides the last-processed epoch, causing the bot to skip ahead'
+      }
+      tone="amber"
+    >
+      <DetailBlock>
+        <Field
+          label="Last processed epoch"
+          hint="The bot skips any epoch at or below this number"
+          value={
+            changed ? (
+              <ValueChange
+                from={currentEpoch!.toLocaleString()}
+                to={newEpoch!.toLocaleString()}
+                tone="amber"
+              />
+            ) : (
+              (newEpoch?.toLocaleString() ?? '—')
+            )
+          }
+        />
+        {admin && <AddressWithButtons address={admin} label="Admin" />}
+      </DetailBlock>
+    </SummaryShell>
+  );
+};
+
+/** `acquire_epoch_lock` — bot claims exclusive processing of an epoch. */
+export const DelegationAcquireEpochLockSummary: React.FC<InstructionSummaryProps> = ({
+  instruction,
+  connection,
+}) => {
+  const { clusterInfo } = useDelegationClusterInfo(instruction, connection);
+  const bot = accountByName(instruction, 'bot', 2);
+
+  const currentEpoch = toNumber(instruction.args?.current_epoch);
+  const timeoutSlots = toNumber(instruction.args?.timeout_slots);
+
+  return (
+    <SummaryShell
+      icon="🔒"
+      title="Acquire Epoch Lock"
+      subtitle="Claims exclusive rights to process an epoch so two bot instances can't run at once"
+      tone="gray"
+    >
+      <DetailBlock>
+        {currentEpoch !== null && <Field label="Epoch" value={currentEpoch.toLocaleString()} />}
+        {timeoutSlots !== null && (
+          <Field
+            label="Timeout"
+            value={`${timeoutSlots.toLocaleString()} slots`}
+            hint="The lock expires automatically after this many slots"
+          />
+        )}
+        <ClusterState
+          lastEpoch={clusterInfo ? toNumber(clusterInfo.last_updated_epoch) : null}
+          lockedUntilSlot={clusterInfo ? toNumber(clusterInfo.locked_until_slot) : null}
+        />
+        {bot && <AddressWithButtons address={bot} label="Bot" />}
+      </DetailBlock>
+    </SummaryShell>
+  );
+};
+
+/** `release_epoch_lock` — bot releases its own lock after finishing. */
+export const DelegationReleaseEpochLockSummary: React.FC<InstructionSummaryProps> = ({
+  instruction,
+  connection,
+}) => {
+  const { clusterInfo } = useDelegationClusterInfo(instruction, connection);
+  const bot = accountByName(instruction, 'bot', 2);
+
+  return (
+    <SummaryShell
+      icon="🔓"
+      title="Release Epoch Lock"
+      subtitle="Releases the bot's processing lock so the next run can proceed"
+      tone="green"
+    >
+      <DetailBlock>
+        <ClusterState
+          lastEpoch={clusterInfo ? toNumber(clusterInfo.last_updated_epoch) : null}
+          lockedUntilSlot={clusterInfo ? toNumber(clusterInfo.locked_until_slot) : null}
+        />
+        {bot && <AddressWithButtons address={bot} label="Bot" />}
+      </DetailBlock>
+    </SummaryShell>
+  );
+};
+
+/** `force_release_lock` — admin break-glass for a lock left behind by a crashed bot. */
+export const DelegationForceReleaseLockSummary: React.FC<InstructionSummaryProps> = ({
+  instruction,
+  connection,
+}) => {
+  const { clusterInfo } = useDelegationClusterInfo(instruction, connection);
+  const admin = accountByName(instruction, 'admin', 2);
+  const lockedUntilSlot = clusterInfo ? toNumber(clusterInfo.locked_until_slot) : null;
+
+  return (
+    <SummaryShell
+      icon="🛠️"
+      title="Force Release Epoch Lock"
+      subtitle={
+        lockedUntilSlot === 0
+          ? 'Clears the processing lock — no lock is currently held'
+          : 'Admin override that clears a stuck processing lock, e.g. one left behind by a crashed bot'
+      }
+      tone="amber"
+    >
+      <DetailBlock>
+        <ClusterState
+          lastEpoch={clusterInfo ? toNumber(clusterInfo.last_updated_epoch) : null}
+          lockedUntilSlot={lockedUntilSlot}
+        />
+        {admin && <AddressWithButtons address={admin} label="Admin" />}
+      </DetailBlock>
+    </SummaryShell>
+  );
+};

--- a/src/components/instructions/summaries/delegation/UpdateConfigSummary.tsx
+++ b/src/components/instructions/summaries/delegation/UpdateConfigSummary.tsx
@@ -1,0 +1,185 @@
+import React, { useMemo } from 'react';
+import { InstructionSummaryProps } from '@/lib/instructions/types';
+import { AddressWithButtons } from '@/components/AddressWithButtons';
+import { CONFIG_FIELDS, ConfigFieldSpec } from '@/lib/delegation/configFields';
+import { percentChange, toBigInt } from '@/lib/delegation/values';
+import { DetailBlock, Field, SummaryShell, ValueChange, accountByName } from './shared';
+import { useDelegationConfig } from './hooks';
+
+type FieldState = 'changed' | 'unchanged' | 'unknown' | 'untouched';
+
+interface EvaluatedField {
+  spec: ConfigFieldSpec;
+  state: FieldState;
+  submitted: unknown;
+  current: unknown;
+}
+
+/** Compare a submitted param against the on-chain value across BN/number/bool forms. */
+function isSameValue(a: unknown, b: unknown): boolean {
+  if (typeof a === 'boolean' || typeof b === 'boolean') return Boolean(a) === Boolean(b);
+
+  const left = toBigInt(a);
+  const right = toBigInt(b);
+  if (left !== null && right !== null) return left === right;
+
+  return String(a) === String(b);
+}
+
+/** Signed percentage annotation for a numeric before -> after pair. */
+function deltaLabel(current: unknown, submitted: unknown): string | null {
+  const from = toBigInt(current);
+  const to = toBigInt(submitted);
+  if (from === null || to === null) return null;
+
+  const change = percentChange(from, to);
+  if (change === null || !Number.isFinite(change)) return null;
+
+  const rounded = Math.abs(change) >= 10 ? Math.round(change) : Number(change.toFixed(1));
+  if (rounded === 0) return null;
+
+  return `${rounded > 0 ? '+' : ''}${rounded}%`;
+}
+
+/**
+ * Summary for the delegation program's `update_config` instruction.
+ *
+ * The bot submits every parameter on each proposal, so the raw arguments are a
+ * wall of 14 values that mostly restate the current config. This fetches the
+ * live `DelegationConfig` and leads with the parameters that actually change.
+ */
+export const DelegationUpdateConfigSummary: React.FC<InstructionSummaryProps> = ({
+  instruction,
+  connection,
+}) => {
+  const { config: currentConfig, loading } = useDelegationConfig(instruction, connection);
+
+  const params = (instruction.args?.params ?? instruction.args ?? {}) as Record<string, unknown>;
+  const configAccount = accountByName(instruction, 'config', 0);
+  const authority = accountByName(instruction, 'authority', 1);
+
+  const fields = useMemo<EvaluatedField[]>(
+    () =>
+      CONFIG_FIELDS.map((spec) => {
+        const submitted = params[spec.key];
+        if (submitted === null || submitted === undefined) {
+          return { spec, state: 'untouched' as const, submitted, current: undefined };
+        }
+
+        if (!currentConfig) {
+          return { spec, state: 'unknown' as const, submitted, current: undefined };
+        }
+
+        const current = currentConfig[spec.key];
+        return {
+          spec,
+          state: isSameValue(submitted, current) ? ('unchanged' as const) : ('changed' as const),
+          submitted,
+          current,
+        };
+      }),
+    [params, currentConfig]
+  );
+
+  const changed = fields.filter((field) => field.state === 'changed');
+  const unchanged = fields.filter((field) => field.state === 'unchanged');
+  const untouched = fields.filter((field) => field.state === 'untouched');
+  const submittedCount = fields.length - untouched.length;
+
+  const pausing = changed.some(
+    (field) => field.spec.key === 'emergency_pause' && field.submitted === true
+  );
+
+  const subtitle = loading
+    ? 'Comparing against the current on-chain config…'
+    : !currentConfig
+      ? `Sets ${submittedCount} delegation parameter${submittedCount === 1 ? '' : 's'} (current config unavailable — showing submitted values)`
+      : changed.length === 0
+        ? `No effective change — all ${submittedCount} submitted values match the current config`
+        : `${changed.length} of ${submittedCount} submitted parameter${submittedCount === 1 ? '' : 's'} change`;
+
+  return (
+    <SummaryShell
+      icon={pausing ? '⏸️' : '⚙️'}
+      title="Update Delegation Config"
+      subtitle={subtitle}
+      tone={pausing ? 'red' : changed.length > 0 ? 'amber' : 'blue'}
+    >
+      {changed.length > 0 && (
+        <DetailBlock>
+          <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            Changes
+          </div>
+          {changed.map(({ spec, submitted, current }) => {
+            const delta = deltaLabel(current, submitted);
+            return (
+              <Field
+                key={spec.key}
+                label={spec.label}
+                hint={spec.description}
+                value={
+                  <>
+                    <ValueChange
+                      from={spec.format(current)}
+                      to={spec.format(submitted)}
+                      tone={spec.key === 'emergency_pause' && submitted === true ? 'red' : 'amber'}
+                    />
+                    {delta && <span className="ml-2 text-xs text-muted-foreground">({delta})</span>}
+                  </>
+                }
+              />
+            );
+          })}
+        </DetailBlock>
+      )}
+
+      {!loading && !currentConfig && submittedCount > 0 && (
+        <DetailBlock>
+          <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            Submitted values
+          </div>
+          {fields
+            .filter((field) => field.state === 'unknown')
+            .map(({ spec, submitted }) => (
+              <Field
+                key={spec.key}
+                label={spec.label}
+                hint={spec.description}
+                value={spec.format(submitted)}
+              />
+            ))}
+        </DetailBlock>
+      )}
+
+      {unchanged.length > 0 && (
+        <details className="rounded-lg border border-border/50 bg-muted/20 p-3">
+          <summary className="cursor-pointer text-xs text-muted-foreground">
+            {unchanged.length} parameter{unchanged.length === 1 ? '' : 's'} resubmitted unchanged
+          </summary>
+          <div className="mt-2 space-y-1">
+            {unchanged.map(({ spec, submitted }) => (
+              <div key={spec.key} className="flex flex-wrap items-baseline gap-x-2">
+                <span className="text-xs text-muted-foreground">{spec.label}:</span>
+                <span className="font-mono text-xs text-muted-foreground">
+                  {spec.format(submitted)}
+                </span>
+              </div>
+            ))}
+          </div>
+        </details>
+      )}
+
+      {untouched.length > 0 && (
+        <div className="text-xs text-muted-foreground">
+          {untouched.length} parameter{untouched.length === 1 ? '' : 's'} not included — left at the
+          current value.
+        </div>
+      )}
+
+      <DetailBlock>
+        {configAccount && <AddressWithButtons address={configAccount} label="Config" />}
+        {authority && <AddressWithButtons address={authority} label="Authority" />}
+      </DetailBlock>
+    </SummaryShell>
+  );
+};

--- a/src/components/instructions/summaries/delegation/ValidatorSummaries.tsx
+++ b/src/components/instructions/summaries/delegation/ValidatorSummaries.tsx
@@ -1,0 +1,363 @@
+import React from 'react';
+import { InstructionSummaryProps } from '@/lib/instructions/types';
+import { AddressWithButtons } from '@/components/AddressWithButtons';
+import {
+  DELEGATION_CRITERIA,
+  VALIDATOR_STATUSES,
+  enumVariantName,
+  formatBasisPoints,
+  toNumber,
+} from '@/lib/delegation/values';
+import {
+  DetailBlock,
+  Field,
+  SummaryShell,
+  Tone,
+  ValidatorTarget,
+  ValueChange,
+  accountByName,
+} from './shared';
+import { useDelegationValidator } from './hooks';
+
+/** Describe a `ValidatorStatus` enum value, falling back to the raw variant. */
+function describeStatus(value: unknown): { label: string; description?: string } {
+  const variant = enumVariantName(value);
+  if (!variant) return { label: 'Unknown' };
+  return VALIDATOR_STATUSES[variant] ?? { label: variant };
+}
+
+const STATUS_TONE: Record<string, Tone> = {
+  Approved: 'green',
+  Rejected: 'red',
+  Pending: 'amber',
+};
+
+/**
+ * `create_validator` — admin registers a validator record with an initial status.
+ */
+export const DelegationCreateValidatorSummary: React.FC<InstructionSummaryProps> = ({
+  instruction,
+  connection,
+}) => {
+  const { voteAccount, validatorPda } = useDelegationValidator(instruction, connection);
+  const status = describeStatus(instruction.args?.status);
+
+  return (
+    <SummaryShell
+      icon="➕"
+      title="Create Validator Record"
+      subtitle={`Registers a validator with the delegation program as ${status.label}`}
+      tone="blue"
+    >
+      <DetailBlock>
+        <ValidatorTarget voteAccount={voteAccount} validatorPda={validatorPda} />
+        <Field
+          label="Initial status"
+          value={status.label}
+          hint={status.description}
+          tone={STATUS_TONE[status.label]}
+        />
+      </DetailBlock>
+    </SummaryShell>
+  );
+};
+
+/**
+ * `apply_validator` — a validator operator self-registers, creating a Pending record.
+ */
+export const DelegationApplyValidatorSummary: React.FC<InstructionSummaryProps> = ({
+  instruction,
+  connection,
+}) => {
+  const { voteAccount, validatorPda } = useDelegationValidator(instruction, connection);
+  const signer = accountByName(instruction, 'signer', 2);
+
+  return (
+    <SummaryShell
+      icon="📝"
+      title="Apply to Delegation Program"
+      subtitle="Creates a pending application for review — no stake is delegated yet"
+      tone="blue"
+    >
+      <DetailBlock>
+        <ValidatorTarget voteAccount={voteAccount} validatorPda={validatorPda} />
+        {signer && <AddressWithButtons address={signer} label="Applicant" />}
+      </DetailBlock>
+    </SummaryShell>
+  );
+};
+
+/** Shared body for the no-argument approve / reject / remove instructions. */
+const ValidatorDecisionSummary: React.FC<
+  InstructionSummaryProps & {
+    icon: string;
+    title: string;
+    subtitle: string;
+    tone: Tone;
+    adminAccount?: string;
+  }
+> = ({ instruction, connection, icon, title, subtitle, tone, adminAccount = 'admin' }) => {
+  const { voteAccount, validatorPda, info } = useDelegationValidator(instruction, connection);
+  const admin = accountByName(instruction, adminAccount, 1);
+  const currentStatus = info ? describeStatus(info.status) : null;
+
+  return (
+    <SummaryShell icon={icon} title={title} subtitle={subtitle} tone={tone}>
+      <DetailBlock>
+        <ValidatorTarget voteAccount={voteAccount} validatorPda={validatorPda} />
+        {currentStatus && (
+          <Field
+            label="Current status"
+            value={currentStatus.label}
+            tone={STATUS_TONE[currentStatus.label]}
+          />
+        )}
+        {admin && <AddressWithButtons address={admin} label="Admin" />}
+      </DetailBlock>
+    </SummaryShell>
+  );
+};
+
+/** `approve_validator` — makes a validator eligible to receive delegated stake. */
+export const DelegationApproveValidatorSummary: React.FC<InstructionSummaryProps> = (props) => (
+  <ValidatorDecisionSummary
+    {...props}
+    icon="✅"
+    title="Approve Validator"
+    subtitle="Makes this validator eligible to receive stake from the delegation program"
+    tone="green"
+  />
+);
+
+/** `reject_validator` — marks a validator ineligible for delegation. */
+export const DelegationRejectValidatorSummary: React.FC<InstructionSummaryProps> = (props) => (
+  <ValidatorDecisionSummary
+    {...props}
+    icon="🚫"
+    title="Reject Validator"
+    subtitle="Marks this validator ineligible — any delegated stake will be withdrawn"
+    tone="red"
+  />
+);
+
+/** `remove_validator` — closes the validator record entirely. */
+export const DelegationRemoveValidatorSummary: React.FC<InstructionSummaryProps> = (props) => (
+  <ValidatorDecisionSummary
+    {...props}
+    icon="🗑️"
+    title="Remove Validator"
+    subtitle="Closes this validator's record and drops it from the delegation program"
+    tone="red"
+  />
+);
+
+/**
+ * `withdraw_validator` — an operator withdraws their own validator record and
+ * reclaims its rent.
+ */
+export const DelegationWithdrawValidatorSummary: React.FC<InstructionSummaryProps> = ({
+  instruction,
+  connection,
+}) => {
+  const { voteAccount, validatorPda } = useDelegationValidator(instruction, connection);
+  const signer = accountByName(instruction, 'signer', 2);
+  const refundee = accountByName(instruction, 'refundee', 3);
+
+  return (
+    <SummaryShell
+      icon="↩️"
+      title="Withdraw Validator"
+      subtitle="Operator removes their own validator record and reclaims its rent"
+      tone="amber"
+    >
+      <DetailBlock>
+        <ValidatorTarget voteAccount={voteAccount} validatorPda={validatorPda} />
+        {signer && <AddressWithButtons address={signer} label="Signer" />}
+        {refundee && <AddressWithButtons address={refundee} label="Rent to" />}
+      </DetailBlock>
+    </SummaryShell>
+  );
+};
+
+/**
+ * `update_validator_status` — set a validator's status directly, showing the
+ * transition from its current on-chain status where available.
+ */
+export const DelegationUpdateValidatorStatusSummary: React.FC<InstructionSummaryProps> = ({
+  instruction,
+  connection,
+}) => {
+  const { voteAccount, validatorPda, info } = useDelegationValidator(instruction, connection);
+  const admin = accountByName(instruction, 'admin', 1);
+  const newStatus = describeStatus(instruction.args?.new_status);
+  const currentStatus = info ? describeStatus(info.status) : null;
+  const isNoop = currentStatus?.label === newStatus.label;
+
+  return (
+    <SummaryShell
+      icon="🔄"
+      title="Update Validator Status"
+      subtitle={
+        isNoop
+          ? `Already ${newStatus.label} — this proposal changes nothing`
+          : currentStatus
+            ? `Moves this validator from ${currentStatus.label} to ${newStatus.label}`
+            : `Sets this validator to ${newStatus.label}`
+      }
+      tone={isNoop ? 'gray' : (STATUS_TONE[newStatus.label] ?? 'blue')}
+    >
+      <DetailBlock>
+        <ValidatorTarget voteAccount={voteAccount} validatorPda={validatorPda} />
+        <Field
+          label="Status"
+          hint={newStatus.description}
+          value={
+            currentStatus && !isNoop ? (
+              <ValueChange
+                from={currentStatus.label}
+                to={newStatus.label}
+                tone={STATUS_TONE[newStatus.label] ?? 'amber'}
+              />
+            ) : (
+              newStatus.label
+            )
+          }
+          tone={currentStatus && !isNoop ? undefined : STATUS_TONE[newStatus.label]}
+        />
+        {admin && <AddressWithButtons address={admin} label="Admin" />}
+      </DetailBlock>
+    </SummaryShell>
+  );
+};
+
+/**
+ * `update_validator_criteria` — the bot records which eligibility rules a
+ * validator is currently failing. An empty list means it passes everything.
+ */
+export const DelegationUpdateValidatorCriteriaSummary: React.FC<InstructionSummaryProps> = ({
+  instruction,
+  connection,
+}) => {
+  const { voteAccount, validatorPda } = useDelegationValidator(instruction, connection);
+  const bot = accountByName(instruction, 'bot', 1);
+
+  const rawCriteria = instruction.args?.failing_criteria;
+  const criteria: string[] = Array.isArray(rawCriteria)
+    ? rawCriteria.map((entry) => enumVariantName(entry) ?? 'Unknown')
+    : [];
+
+  return (
+    <SummaryShell
+      icon={criteria.length === 0 ? '🟢' : '⚠️'}
+      title="Update Validator Criteria"
+      subtitle={
+        criteria.length === 0
+          ? 'Validator now passes every delegation criterion'
+          : `Validator is failing ${criteria.length} criteri${criteria.length === 1 ? 'on' : 'a'}`
+      }
+      tone={criteria.length === 0 ? 'green' : 'amber'}
+    >
+      <DetailBlock>
+        <ValidatorTarget voteAccount={voteAccount} validatorPda={validatorPda} />
+        {criteria.length > 0 && (
+          <div className="space-y-1 border-t border-border/50 pt-2">
+            {criteria.map((criterion) => {
+              const meta = DELEGATION_CRITERIA[criterion];
+              return (
+                <Field
+                  key={criterion}
+                  label="Failing"
+                  value={meta?.label ?? criterion}
+                  hint={meta?.description}
+                  tone="amber"
+                />
+              );
+            })}
+          </div>
+        )}
+        {bot && <AddressWithButtons address={bot} label="Bot" />}
+      </DetailBlock>
+    </SummaryShell>
+  );
+};
+
+/**
+ * `update_validator_multiplier` — scales how much stake a validator receives
+ * relative to its normal allocation (10000 bps = 100%).
+ */
+export const DelegationUpdateValidatorMultiplierSummary: React.FC<InstructionSummaryProps> = ({
+  instruction,
+  connection,
+}) => {
+  const { voteAccount, validatorPda, info } = useDelegationValidator(instruction, connection);
+  const signer = accountByName(instruction, 'signer', 2);
+
+  const newBps = toNumber(instruction.args?.stake_multiplier_bps);
+  const currentBps = info ? toNumber(info.stake_multiplier_bps) : null;
+  const changed = currentBps !== null && newBps !== null && currentBps !== newBps;
+
+  return (
+    <SummaryShell
+      icon="⚖️"
+      title="Update Stake Multiplier"
+      subtitle={
+        newBps === null
+          ? 'Adjusts how much stake this validator receives'
+          : newBps === 10000
+            ? 'Returns this validator to its full normal stake allocation'
+            : `Scales this validator's stake allocation to ${formatBasisPoints(newBps)} of normal`
+      }
+      tone="purple"
+    >
+      <DetailBlock>
+        <ValidatorTarget voteAccount={voteAccount} validatorPda={validatorPda} />
+        <Field
+          label="Multiplier"
+          hint="10,000 bps = 100% of the validator's normal allocation"
+          value={
+            changed ? (
+              <ValueChange
+                from={formatBasisPoints(currentBps)}
+                to={formatBasisPoints(newBps)}
+                tone="purple"
+              />
+            ) : (
+              `${formatBasisPoints(newBps)} (${newBps?.toLocaleString() ?? '—'} bps)`
+            )
+          }
+        />
+        {signer && <AddressWithButtons address={signer} label="Signer" />}
+      </DetailBlock>
+    </SummaryShell>
+  );
+};
+
+/**
+ * `update_stake_change_epoch` — the bot stamps the epoch in which it last
+ * changed this validator's stake, which gates further rebalancing.
+ */
+export const DelegationUpdateStakeChangeEpochSummary: React.FC<InstructionSummaryProps> = ({
+  instruction,
+  connection,
+}) => {
+  const { voteAccount, validatorPda, info } = useDelegationValidator(instruction, connection);
+  const bot = accountByName(instruction, 'bot', 2);
+  const lastChange = info ? toNumber(info.last_stake_change_epoch) : null;
+
+  return (
+    <SummaryShell
+      icon="⏱️"
+      title="Update Stake Change Epoch"
+      subtitle="Records that this validator's stake changed in the current epoch"
+      tone="gray"
+    >
+      <DetailBlock>
+        <ValidatorTarget voteAccount={voteAccount} validatorPda={validatorPda} />
+        {lastChange !== null && (
+          <Field label="Last change epoch" value={lastChange.toLocaleString()} />
+        )}
+        {bot && <AddressWithButtons address={bot} label="Bot" />}
+      </DetailBlock>
+    </SummaryShell>
+  );
+};

--- a/src/components/instructions/summaries/delegation/hooks.ts
+++ b/src/components/instructions/summaries/delegation/hooks.ts
@@ -1,0 +1,122 @@
+import { useEffect, useState } from 'react';
+import { Connection, PublicKey } from '@solana/web3.js';
+import { DecodedInstruction } from '@/lib/transaction/simpleDecoder';
+import {
+  ClusterInfoAccount,
+  DelegationConfigAccount,
+  ValidatorInfoAccount,
+  fetchClusterInfo,
+  fetchDelegationConfig,
+  fetchValidatorInfo,
+} from '@/lib/delegation/accounts';
+import { accountByName } from './shared';
+
+/**
+ * Run a delegation account fetch, tracking loading state and ignoring results
+ * that arrive after the summary has moved on.
+ */
+function useDelegationAccount<T>(
+  key: string | undefined,
+  load: () => Promise<T | null>
+): { data: T | null; loading: boolean } {
+  const [data, setData] = useState<T | null>(null);
+  const [loading, setLoading] = useState(Boolean(key));
+
+  useEffect(() => {
+    if (!key) {
+      setData(null);
+      setLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+    setLoading(true);
+
+    load()
+      .then((result) => {
+        if (!cancelled) setData(result);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+    // `load` closes over the same inputs `key` is derived from.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [key]);
+
+  return { data, loading };
+}
+
+/** Current on-chain `DelegationConfig` for the deployment an instruction targets. */
+export function useDelegationConfig(
+  instruction: DecodedInstruction,
+  connection: Connection
+): { config: DelegationConfigAccount | null; loading: boolean } {
+  const { data, loading } = useDelegationAccount(`config:${instruction.programId}`, () =>
+    fetchDelegationConfig(connection, instruction.programId)
+  );
+  return { config: data, loading };
+}
+
+/** Current on-chain `ClusterInfo` for the deployment an instruction targets. */
+export function useDelegationClusterInfo(
+  instruction: DecodedInstruction,
+  connection: Connection
+): { clusterInfo: ClusterInfoAccount | null; loading: boolean } {
+  const { data, loading } = useDelegationAccount(`cluster:${instruction.programId}`, () =>
+    fetchClusterInfo(connection, instruction.programId)
+  );
+  return { clusterInfo: data, loading };
+}
+
+export interface DelegationValidatorTarget {
+  /** PDA holding the program's record for this validator. */
+  validatorPda?: string;
+  /** Vote account the instruction acts on, once it can be determined. */
+  voteAccount?: string;
+  /** Current on-chain record, when it exists and could be decoded. */
+  info: ValidatorInfoAccount | null;
+  loading: boolean;
+}
+
+function readPubkeyArg(value: unknown): string | undefined {
+  if (!value) return undefined;
+  if (value instanceof PublicKey) return value.toBase58();
+  if (typeof value === 'string') return value;
+  try {
+    return new PublicKey(value as any).toBase58();
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Resolve which validator a delegation instruction targets.
+ *
+ * Most validator instructions take no arguments — the vote account is only
+ * implied by the `validator` PDA — so the current `ValidatorInfo` is fetched to
+ * name the validator and to show its state before the change.
+ */
+export function useDelegationValidator(
+  instruction: DecodedInstruction,
+  connection: Connection
+): DelegationValidatorTarget {
+  const validatorPda = accountByName(instruction, 'validator', 0);
+  const { data: info, loading } = useDelegationAccount(
+    validatorPda && `validator:${validatorPda}`,
+    () => fetchValidatorInfo(connection, validatorPda!)
+  );
+
+  const voteFromArgs = readPubkeyArg(instruction.args?.vote_account);
+  const voteFromAccounts = accountByName(instruction, 'vote');
+
+  return {
+    validatorPda,
+    voteAccount: voteFromArgs || voteFromAccounts || info?.vote_account?.toBase58(),
+    info,
+    loading,
+  };
+}

--- a/src/components/instructions/summaries/delegation/index.ts
+++ b/src/components/instructions/summaries/delegation/index.ts
@@ -1,0 +1,38 @@
+/**
+ * Instruction summaries for the X1 delegation program.
+ *
+ * These proposals are the program's admin surface — config changes, validator
+ * approvals and authority handovers — so each summary states what the
+ * instruction does and, where a current value can be read from chain, what it
+ * changes rather than only what it sets.
+ */
+export { DelegationUpdateConfigSummary } from './UpdateConfigSummary';
+
+export {
+  DelegationCreateValidatorSummary,
+  DelegationApplyValidatorSummary,
+  DelegationApproveValidatorSummary,
+  DelegationRejectValidatorSummary,
+  DelegationRemoveValidatorSummary,
+  DelegationWithdrawValidatorSummary,
+  DelegationUpdateValidatorStatusSummary,
+  DelegationUpdateValidatorCriteriaSummary,
+  DelegationUpdateValidatorMultiplierSummary,
+  DelegationUpdateStakeChangeEpochSummary,
+} from './ValidatorSummaries';
+
+export {
+  DelegationInitializeConfigSummary,
+  DelegationTransferAuthoritySummary,
+  DelegationUpdateBotAuthoritySummary,
+  DelegationUpdateReviewerAuthoritySummary,
+} from './AuthoritySummaries';
+
+export {
+  DelegationInitializeClusterInfoSummary,
+  DelegationUpdateClusterInfoSummary,
+  DelegationSetClusterEpochSummary,
+  DelegationAcquireEpochLockSummary,
+  DelegationReleaseEpochLockSummary,
+  DelegationForceReleaseLockSummary,
+} from './ClusterSummaries';

--- a/src/components/instructions/summaries/delegation/shared.tsx
+++ b/src/components/instructions/summaries/delegation/shared.tsx
@@ -1,0 +1,147 @@
+import React from 'react';
+import { DecodedInstruction } from '@/lib/transaction/simpleDecoder';
+import { AddressWithButtons } from '@/components/AddressWithButtons';
+import { useValidatorMetadata } from '@/hooks/useValidatorMetadata';
+
+export type Tone = 'blue' | 'green' | 'red' | 'amber' | 'purple' | 'gray';
+
+/**
+ * Full class strings so Tailwind's scanner keeps them — do not build these by
+ * interpolating the tone.
+ */
+const TONE_TEXT: Record<Tone, string> = {
+  blue: 'text-blue-600 dark:text-blue-400',
+  green: 'text-green-600 dark:text-green-400',
+  red: 'text-red-600 dark:text-red-400',
+  amber: 'text-amber-600 dark:text-amber-400',
+  purple: 'text-purple-600 dark:text-purple-400',
+  gray: 'text-foreground',
+};
+
+const TONE_BADGE: Record<Tone, string> = {
+  blue: 'bg-blue-100 dark:bg-blue-900/30',
+  green: 'bg-green-100 dark:bg-green-900/30',
+  red: 'bg-red-100 dark:bg-red-900/30',
+  amber: 'bg-amber-100 dark:bg-amber-900/30',
+  purple: 'bg-purple-100 dark:bg-purple-900/30',
+  gray: 'bg-muted',
+};
+
+interface SummaryShellProps {
+  icon: string;
+  title: string;
+  subtitle: React.ReactNode;
+  tone?: Tone;
+  children?: React.ReactNode;
+}
+
+/**
+ * Shared frame for every delegation program summary: icon, headline of what the
+ * instruction does, and an optional detail block.
+ */
+export const SummaryShell: React.FC<SummaryShellProps> = ({
+  icon,
+  title,
+  subtitle,
+  tone = 'blue',
+  children,
+}) => (
+  <div className="space-y-3 text-sm">
+    <div className="flex items-center gap-3">
+      <div
+        className={`flex h-8 w-8 shrink-0 items-center justify-center rounded-full ${TONE_BADGE[tone]}`}
+      >
+        <span className="text-lg">{icon}</span>
+      </div>
+      <div className="flex-1">
+        <div className={`font-semibold ${TONE_TEXT[tone]}`}>{title}</div>
+        <div className="text-xs text-muted-foreground">{subtitle}</div>
+      </div>
+    </div>
+    {children}
+  </div>
+);
+
+/** Bordered container used for the detail rows under a summary headline. */
+export const DetailBlock: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <div className="space-y-2 rounded-lg border border-border/50 bg-muted/30 p-3">{children}</div>
+);
+
+interface FieldProps {
+  label: string;
+  value: React.ReactNode;
+  hint?: string;
+  tone?: Tone;
+}
+
+/** A single label / value row, with an optional explanation underneath. */
+export const Field: React.FC<FieldProps> = ({ label, value, hint, tone }) => (
+  <div>
+    <div className="flex flex-wrap items-baseline gap-x-2">
+      <span className="text-xs text-muted-foreground">{label}:</span>
+      <span className={`font-mono text-sm ${tone ? TONE_TEXT[tone] : ''}`}>{value}</span>
+    </div>
+    {hint && <div className="text-xs text-muted-foreground/80">{hint}</div>}
+  </div>
+);
+
+/** Renders `before → after` with the new value emphasized. */
+export const ValueChange: React.FC<{ from: string; to: string; tone?: Tone }> = ({
+  from,
+  to,
+  tone = 'amber',
+}) => (
+  <span className="font-mono">
+    <span className="text-muted-foreground line-through">{from}</span>
+    <span className="mx-1.5 text-muted-foreground">→</span>
+    <span className={`font-semibold ${TONE_TEXT[tone]}`}>{to}</span>
+  </span>
+);
+
+/**
+ * Identifies the validator an instruction acts on: gossip name when the Config
+ * program has one, plus the vote account and the program's record for it.
+ */
+export const ValidatorTarget: React.FC<{ voteAccount?: string; validatorPda?: string }> = ({
+  voteAccount,
+  validatorPda,
+}) => {
+  const { data: metadata } = useValidatorMetadata(voteAccount);
+
+  return (
+    <>
+      {metadata?.name && (
+        <div className="flex items-center gap-2">
+          {metadata.avatarUrl && (
+            <img
+              src={metadata.avatarUrl}
+              alt={metadata.name}
+              className="h-5 w-5 rounded-full"
+              onError={(e) => {
+                e.currentTarget.style.display = 'none';
+              }}
+            />
+          )}
+          <span className="font-medium">{metadata.name}</span>
+        </div>
+      )}
+      {voteAccount && <AddressWithButtons address={voteAccount} label="Vote" />}
+      {validatorPda && <AddressWithButtons address={validatorPda} label="Record" />}
+    </>
+  );
+};
+
+/**
+ * Look up an instruction account by its IDL name, falling back to a positional
+ * index so a summary still renders if the bundled IDL drifts from the program.
+ */
+export function accountByName(
+  instruction: DecodedInstruction,
+  name: string,
+  fallbackIndex?: number
+): string | undefined {
+  const match = instruction.accounts?.find((account) => account.name === name);
+  if (match) return match.pubkey;
+  if (fallbackIndex !== undefined) return instruction.accounts?.[fallbackIndex]?.pubkey;
+  return undefined;
+}

--- a/src/lib/delegation/accounts.ts
+++ b/src/lib/delegation/accounts.ts
@@ -1,0 +1,200 @@
+import { Connection, PublicKey } from '@solana/web3.js';
+import { BorshAccountsCoder } from '@coral-xyz/anchor';
+import delegationProgramIdl from '../idls/delegation_program.json';
+
+/**
+ * Program IDs the delegation program is deployed under. The UI runs against
+ * several networks from one bundle, so every known deployment is registered and
+ * PDAs are derived from whichever ID the instruction actually used.
+ */
+export const DELEGATION_PROGRAM_IDS = {
+  mainnet: 'x1Dp8D2X1nkHXZbEUQrh58mrUUSwEynYoVdXG5tE268',
+  testnet: 'X1DPvnLXekvd6EtDsPVqahzhziKx3Zj1z8WkD93xebg',
+  localnet: 'X1dpTaMXkdEHQwhUk5oidxK9RXer8WoUCinWTyRmVjQ',
+} as const;
+
+export const DELEGATION_PROGRAM_ID_LIST: string[] = Object.values(DELEGATION_PROGRAM_IDS);
+
+export const DELEGATION_CONFIG_SEED = 'delegation_config';
+export const CLUSTER_INFO_SEED = 'cluster_info';
+export const VALIDATOR_SEED = 'validator';
+
+function toPublicKey(value: string | PublicKey): PublicKey {
+  return typeof value === 'string' ? new PublicKey(value) : value;
+}
+
+/** Derive the singleton `DelegationConfig` PDA for a given deployment. */
+export function getDelegationConfigPda(programId: string | PublicKey): PublicKey {
+  return PublicKey.findProgramAddressSync(
+    [Buffer.from(DELEGATION_CONFIG_SEED)],
+    toPublicKey(programId)
+  )[0];
+}
+
+/** Derive the singleton `ClusterInfo` PDA for a given deployment. */
+export function getClusterInfoPda(programId: string | PublicKey): PublicKey {
+  return PublicKey.findProgramAddressSync(
+    [Buffer.from(CLUSTER_INFO_SEED)],
+    toPublicKey(programId)
+  )[0];
+}
+
+/** Derive the `ValidatorInfo` PDA for a vote account. */
+export function getValidatorInfoPda(
+  programId: string | PublicKey,
+  voteAccount: string | PublicKey
+): PublicKey {
+  return PublicKey.findProgramAddressSync(
+    [Buffer.from(VALIDATOR_SEED), toPublicKey(voteAccount).toBuffer()],
+    toPublicKey(programId)
+  )[0];
+}
+
+/**
+ * The on-chain `DelegationConfig`. Numeric fields keep their decoded form (BN
+ * for u64s); use the helpers in `values.ts` to normalize them.
+ */
+export interface DelegationConfigAccount {
+  version: number;
+  authority: PublicKey;
+  max_commission_percent: number;
+  min_self_stake: unknown;
+  max_total_stake: unknown;
+  max_validator_stake_pct: number;
+  skip_rate_tolerance_pct: number;
+  vote_credits_threshold_pct: number;
+  min_validator_version: number;
+  reserve_stake_pct: number;
+  max_validators: number;
+  emergency_pause: boolean;
+  last_updated_epoch: unknown;
+  bump: number;
+  stake_matching_cap: unknown;
+  base_allocation_weight: number;
+  match_allocation_weight: number;
+  min_stake_adjustment_pct: number;
+  bot_authority: PublicKey;
+  reviewer_authority: PublicKey;
+}
+
+/** The on-chain `ClusterInfo`, tracking epoch processing and the bot's lock. */
+export interface ClusterInfoAccount {
+  version: number;
+  last_updated_epoch: unknown;
+  bump: number;
+  locked_until_slot: unknown;
+}
+
+/** The on-chain `ValidatorInfo` for a single vote account. */
+export interface ValidatorInfoAccount {
+  version: number;
+  vote_account: PublicKey;
+  status: unknown;
+  last_updated_epoch: unknown;
+  bump: number;
+  failing_criteria: unknown[];
+  stake_multiplier_bps: number;
+  last_stake_change_epoch: unknown;
+}
+
+let accountsCoder: BorshAccountsCoder | null | undefined;
+
+function getAccountsCoder(): BorshAccountsCoder | null {
+  if (accountsCoder === undefined) {
+    try {
+      accountsCoder = new BorshAccountsCoder(delegationProgramIdl as any);
+    } catch (error) {
+      console.warn('Failed to build delegation program accounts coder:', error);
+      accountsCoder = null;
+    }
+  }
+  return accountsCoder;
+}
+
+const CACHE_TTL_MS = 30_000;
+const accountCache = new Map<string, { fetchedAt: number; value: Promise<unknown> }>();
+
+/**
+ * Fetch and decode a delegation program account, briefly caching the result
+ * because several summaries can render for the same transaction. Resolves to
+ * null when the account is missing or cannot be decoded, and failures are not
+ * cached so a transient RPC error doesn't suppress the next render.
+ */
+function fetchDelegationAccount<T>(
+  connection: Connection,
+  accountName: string,
+  address: PublicKey
+): Promise<T | null> {
+  const cacheKey = `${accountName}:${address.toBase58()}`;
+  const cached = accountCache.get(cacheKey);
+  if (cached && Date.now() - cached.fetchedAt < CACHE_TTL_MS) {
+    return cached.value as Promise<T | null>;
+  }
+
+  const value = (async () => {
+    const coder = getAccountsCoder();
+    if (!coder) return null;
+
+    try {
+      const info = await connection.getAccountInfo(address);
+      if (!info) return null;
+      return coder.decode<T>(accountName, info.data);
+    } catch (error) {
+      console.warn(`Failed to fetch delegation ${accountName} at ${address.toBase58()}:`, error);
+      return null;
+    }
+  })();
+
+  value.then((result) => {
+    if (result === null) accountCache.delete(cacheKey);
+  });
+
+  accountCache.set(cacheKey, { fetchedAt: Date.now(), value });
+  return value as Promise<T | null>;
+}
+
+/**
+ * Fetch the current on-chain `DelegationConfig`. Summaries use this to show
+ * what a proposal actually changes rather than only what it sets.
+ */
+export function fetchDelegationConfig(
+  connection: Connection,
+  programId: string
+): Promise<DelegationConfigAccount | null> {
+  return fetchDelegationAccount<DelegationConfigAccount>(
+    connection,
+    'DelegationConfig',
+    getDelegationConfigPda(programId)
+  );
+}
+
+/**
+ * Fetch the current on-chain `ClusterInfo`, used to show the epoch the bot has
+ * processed and whether an epoch lock is currently held.
+ */
+export function fetchClusterInfo(
+  connection: Connection,
+  programId: string
+): Promise<ClusterInfoAccount | null> {
+  return fetchDelegationAccount<ClusterInfoAccount>(
+    connection,
+    'ClusterInfo',
+    getClusterInfoPda(programId)
+  );
+}
+
+/**
+ * Fetch a `ValidatorInfo` by its PDA. Most validator instructions carry no
+ * arguments, so resolving the PDA is the only way to name the validator a
+ * proposal acts on.
+ */
+export function fetchValidatorInfo(
+  connection: Connection,
+  validatorPda: string | PublicKey
+): Promise<ValidatorInfoAccount | null> {
+  return fetchDelegationAccount<ValidatorInfoAccount>(
+    connection,
+    'ValidatorInfo',
+    toPublicKey(validatorPda)
+  );
+}

--- a/src/lib/delegation/configFields.ts
+++ b/src/lib/delegation/configFields.ts
@@ -1,0 +1,123 @@
+import { DelegationConfigAccount } from './accounts';
+import { formatXNT } from '../utils/formatters';
+import { formatValidatorVersion, toBigInt, toNumber } from './values';
+
+/**
+ * Describes one `UpdateConfigParams` field: how to label it, what it controls,
+ * and how to turn a raw decoded value into something readable.
+ */
+export interface ConfigFieldSpec {
+  key: keyof DelegationConfigAccount & string;
+  label: string;
+  description: string;
+  format: (value: unknown) => string;
+}
+
+const formatPercent = (value: unknown): string => {
+  const n = toNumber(value);
+  return n === null ? '—' : `${n}%`;
+};
+
+const formatCount = (value: unknown): string => {
+  const n = toNumber(value);
+  return n === null ? '—' : n.toLocaleString();
+};
+
+const formatLamports = (value: unknown): string => {
+  const big = toBigInt(value);
+  return big === null ? '—' : formatXNT(big);
+};
+
+const formatBool = (value: unknown): string => (value ? 'Enabled' : 'Disabled');
+
+/**
+ * Every field of `UpdateConfigParams`, in the order the program declares them.
+ * The summary renders straight from this list, so a new config parameter only
+ * needs an entry here plus a refreshed IDL.
+ */
+export const CONFIG_FIELDS: ConfigFieldSpec[] = [
+  {
+    key: 'max_commission_percent',
+    label: 'Max commission',
+    description: 'Highest commission a validator may charge and stay eligible for delegation',
+    format: formatPercent,
+  },
+  {
+    key: 'min_self_stake',
+    label: 'Min self-stake',
+    description: 'Stake a validator must put up itself to qualify for delegation',
+    format: formatLamports,
+  },
+  {
+    key: 'max_total_stake',
+    label: 'Max total stake',
+    description: 'Hard cap on the total stake any single validator may hold',
+    format: formatLamports,
+  },
+  {
+    key: 'max_validator_stake_pct',
+    label: 'Max network share',
+    description: "Cap on one validator's share of total network stake",
+    format: formatPercent,
+  },
+  {
+    key: 'skip_rate_tolerance_pct',
+    label: 'Skip rate tolerance',
+    description: 'How far above the cluster average skip rate a validator may drift',
+    format: formatPercent,
+  },
+  {
+    key: 'vote_credits_threshold_pct',
+    label: 'Vote credits threshold',
+    description: 'Minimum vote credits, as a share of the cluster average',
+    format: formatPercent,
+  },
+  {
+    key: 'min_validator_version',
+    label: 'Min validator version',
+    description: 'Oldest client version still eligible for delegation',
+    format: (value) => formatValidatorVersion(toNumber(value)),
+  },
+  {
+    key: 'reserve_stake_pct',
+    label: 'Reserve stake',
+    description: 'Share of the pool held back as reserve instead of being delegated',
+    format: formatPercent,
+  },
+  {
+    key: 'max_validators',
+    label: 'Max validators',
+    description: 'Maximum number of validators the program will delegate to',
+    format: formatCount,
+  },
+  {
+    key: 'emergency_pause',
+    label: 'Emergency pause',
+    description: 'Halts delegation activity until cleared',
+    format: formatBool,
+  },
+  {
+    key: 'stake_matching_cap',
+    label: 'Stake matching cap',
+    description: "Most stake the program will match 1:1 against a validator's external stake",
+    format: formatLamports,
+  },
+  {
+    key: 'base_allocation_weight',
+    label: 'Base allocation weight',
+    description: 'Share of delegatable stake handed out as the flat base allocation',
+    format: formatPercent,
+  },
+  {
+    key: 'match_allocation_weight',
+    label: 'Match allocation weight',
+    description: 'Share of delegatable stake handed out as 1:1 matching',
+    format: formatPercent,
+  },
+  {
+    key: 'min_stake_adjustment_pct',
+    label: 'Min stake adjustment',
+    description: "Smallest change that triggers a rebalance of a validator's stake",
+    format: formatPercent,
+  },
+];

--- a/src/lib/delegation/values.ts
+++ b/src/lib/delegation/values.ts
@@ -1,0 +1,145 @@
+/**
+ * Value helpers for delegation program instruction data.
+ *
+ * Anchor's BorshInstructionCoder hands back BN instances for u64 fields and
+ * `{ variantName: {} }` objects for enums, so summaries need a small amount of
+ * normalization before anything can be displayed or compared.
+ */
+
+/**
+ * Coerce a decoded numeric arg (BN, string, number, bigint) to a bigint.
+ * Returns null when the value is absent or not numeric.
+ */
+export function toBigInt(value: unknown): bigint | null {
+  if (value === null || value === undefined) return null;
+  if (typeof value === 'bigint') return value;
+  if (typeof value === 'number') return Number.isFinite(value) ? BigInt(value) : null;
+
+  // BN and other objects expose a base-10 toString()
+  const asString = typeof value === 'string' ? value : String(value);
+  return /^-?\d+$/.test(asString) ? BigInt(asString) : null;
+}
+
+/**
+ * Coerce a decoded numeric arg to a JS number. Safe for the u8/u16/u32 fields
+ * the delegation program uses; returns null for anything non-numeric.
+ */
+export function toNumber(value: unknown): number | null {
+  const big = toBigInt(value);
+  return big === null ? null : Number(big);
+}
+
+/**
+ * Extract the variant name from an Anchor enum value (`{ approved: {} }`).
+ * Anchor lowercases the first letter, so the raw key is title-cased back.
+ */
+export function enumVariantName(value: unknown): string | null {
+  if (typeof value === 'string') return value;
+  if (!value || typeof value !== 'object') return null;
+
+  const [variant] = Object.keys(value as Record<string, unknown>);
+  if (!variant) return null;
+
+  return variant.charAt(0).toUpperCase() + variant.slice(1);
+}
+
+/**
+ * Render a validator version packed by the program as
+ * `major * 1_000_000 + minor * 1_000 + patch`.
+ */
+export function formatValidatorVersion(packed: number | null | undefined): string {
+  if (packed === null || packed === undefined || !Number.isFinite(packed)) return '—';
+
+  const major = Math.floor(packed / 1_000_000);
+  const minor = Math.floor(packed / 1_000) % 1_000;
+  const patch = packed % 1_000;
+
+  return `${major}.${minor}.${patch}`;
+}
+
+/**
+ * Format a basis-points stake multiplier (10000 bps = 100%).
+ */
+export function formatBasisPoints(bps: number | null | undefined): string {
+  if (bps === null || bps === undefined || !Number.isFinite(bps)) return '—';
+  return `${(bps / 100).toLocaleString(undefined, { maximumFractionDigits: 2 })}%`;
+}
+
+/**
+ * Percentage change between two values, for annotating a before -> after pair.
+ * Returns null when there is no meaningful baseline to compare against.
+ */
+export function percentChange(from: bigint, to: bigint): number | null {
+  if (from === BigInt(0)) return null;
+
+  const delta = Number(to - from);
+  const base = Math.abs(Number(from));
+  if (!Number.isFinite(delta) || !Number.isFinite(base) || base === 0) return null;
+
+  return (delta / base) * 100;
+}
+
+/**
+ * Human labels for the `DelegationCriterion` enum, plus what failing the
+ * criterion means for the validator.
+ */
+export const DELEGATION_CRITERIA: Record<string, { label: string; description: string }> = {
+  MaxCommission: {
+    label: 'Commission too high',
+    description: 'Commission exceeds the configured maximum',
+  },
+  MinSelfStake: {
+    label: 'Self-stake too low',
+    description: 'Validator self-stake is below the required minimum',
+  },
+  MaxTotalStake: {
+    label: 'Total stake too high',
+    description: 'Validator holds more stake than the per-validator cap',
+  },
+  MinVoteCredits: {
+    label: 'Vote credits too low',
+    description: 'Vote credits are below the threshold vs. the cluster average',
+  },
+  MaxSkipRate: {
+    label: 'Skip rate too high',
+    description: 'Skip rate exceeds the tolerance above the cluster average',
+  },
+  MinValidatorVersion: {
+    label: 'Version too old',
+    description: 'Validator is running below the minimum required version',
+  },
+  Delinquent: {
+    label: 'Delinquent',
+    description: 'Validator is not voting',
+  },
+  NoVersionInfo: {
+    label: 'No version reported',
+    description: 'Validator does not report a version over gossip',
+  },
+  NotValidator: {
+    label: 'Not an active validator',
+    description: 'Vote account is not part of the active validator set',
+  },
+  MaxTotalStakePercent: {
+    label: 'Network share too high',
+    description: 'Validator controls more than the allowed share of network stake',
+  },
+};
+
+/**
+ * Human labels for the `ValidatorStatus` enum.
+ */
+export const VALIDATOR_STATUSES: Record<string, { label: string; description: string }> = {
+  Pending: {
+    label: 'Pending',
+    description: 'Awaiting review — not yet eligible for delegation',
+  },
+  Approved: {
+    label: 'Approved',
+    description: 'Eligible to receive stake from the delegation program',
+  },
+  Rejected: {
+    label: 'Rejected',
+    description: 'Not eligible to receive stake from the delegation program',
+  },
+};

--- a/src/lib/idls/delegation_program.json
+++ b/src/lib/idls/delegation_program.json
@@ -1,5 +1,5 @@
 {
-  "address": "X1dpTaMXkdEHQwhUk5oidxK9RXer8WoUCinWTyRmVjQ",
+  "address": "x1Dp8D2X1nkHXZbEUQrh58mrUUSwEynYoVdXG5tE268",
   "metadata": {
     "name": "delegation_program",
     "version": "0.1.0",
@@ -8,6 +8,95 @@
   },
   "instructions": [
     {
+      "name": "acquire_epoch_lock",
+      "docs": [
+        "Acquire epoch lock to prevent multiple bot instances from processing simultaneously"
+      ],
+      "discriminator": [
+        118,
+        68,
+        59,
+        204,
+        160,
+        233,
+        81,
+        81
+      ],
+      "accounts": [
+        {
+          "name": "cluster_info",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  99,
+                  108,
+                  117,
+                  115,
+                  116,
+                  101,
+                  114,
+                  95,
+                  105,
+                  110,
+                  102,
+                  111
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "config",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  100,
+                  101,
+                  108,
+                  101,
+                  103,
+                  97,
+                  116,
+                  105,
+                  111,
+                  110,
+                  95,
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "bot",
+          "docs": [
+            "The bot authority that can acquire the lock"
+          ],
+          "signer": true
+        }
+      ],
+      "args": [
+        {
+          "name": "current_epoch",
+          "type": "u64"
+        },
+        {
+          "name": "timeout_slots",
+          "type": "u64"
+        }
+      ]
+    },
+    {
       "name": "apply_validator",
       "docs": [
         "Apply for the delegation program",
@@ -15,7 +104,16 @@
         "Validators can self-register by calling this instruction.",
         "On success the validator will be moved to the `ValidatorStatus::Pending` state"
       ],
-      "discriminator": [176, 87, 141, 154, 249, 219, 197, 248],
+      "discriminator": [
+        176,
+        87,
+        141,
+        154,
+        249,
+        219,
+        197,
+        248
+      ],
       "accounts": [
         {
           "name": "validator",
@@ -24,17 +122,36 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [118, 97, 108, 105, 100, 97, 116, 111, 114]
+                "value": [
+                  118,
+                  97,
+                  108,
+                  105,
+                  100,
+                  97,
+                  116,
+                  111,
+                  114
+                ]
               },
               {
-                "kind": "account",
-                "path": "identity"
+                "kind": "arg",
+                "path": "vote_account"
               }
             ]
           }
         },
         {
-          "name": "identity",
+          "name": "vote",
+          "docs": [
+            "The vote account to validate - must be owned by the Vote program"
+          ]
+        },
+        {
+          "name": "signer",
+          "docs": [
+            "The signer who is paying for the account creation and applying"
+          ],
           "writable": true,
           "signer": true
         },
@@ -43,16 +160,30 @@
           "address": "11111111111111111111111111111111"
         }
       ],
-      "args": []
+      "args": [
+        {
+          "name": "vote_account",
+          "type": "pubkey"
+        }
+      ]
     },
     {
       "name": "approve_validator",
       "docs": [
-        "Approve a validator (admin only)",
+        "Approve a validator (admin or reviewer authority)",
         "",
         "On success the validator will be moved to the `ValidatorStatus::Approved` state"
       ],
-      "discriminator": [185, 132, 52, 190, 111, 119, 13, 252],
+      "discriminator": [
+        185,
+        132,
+        52,
+        190,
+        111,
+        119,
+        13,
+        252
+      ],
       "accounts": [
         {
           "name": "validator",
@@ -61,11 +192,21 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [118, 97, 108, 105, 100, 97, 116, 111, 114]
+                "value": [
+                  118,
+                  97,
+                  108,
+                  105,
+                  100,
+                  97,
+                  116,
+                  111,
+                  114
+                ]
               },
               {
                 "kind": "account",
-                "path": "validator.identity",
+                "path": "validator.vote_account",
                 "account": "ValidatorInfo"
               }
             ]
@@ -82,7 +223,23 @@
               {
                 "kind": "const",
                 "value": [
-                  100, 101, 108, 101, 103, 97, 116, 105, 111, 110, 95, 99, 111, 110, 102, 105, 103
+                  100,
+                  101,
+                  108,
+                  101,
+                  103,
+                  97,
+                  116,
+                  105,
+                  111,
+                  110,
+                  95,
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
                 ]
               }
             ]
@@ -98,7 +255,16 @@
         "",
         "Create a new validator account with the specified status"
       ],
-      "discriminator": [223, 156, 228, 103, 198, 99, 177, 99],
+      "discriminator": [
+        223,
+        156,
+        228,
+        103,
+        198,
+        99,
+        177,
+        99
+      ],
       "accounts": [
         {
           "name": "validator",
@@ -107,17 +273,30 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [118, 97, 108, 105, 100, 97, 116, 111, 114]
+                "value": [
+                  118,
+                  97,
+                  108,
+                  105,
+                  100,
+                  97,
+                  116,
+                  111,
+                  114
+                ]
               },
               {
-                "kind": "account",
-                "path": "identity"
+                "kind": "arg",
+                "path": "vote_account"
               }
             ]
           }
         },
         {
-          "name": "identity"
+          "name": "vote",
+          "docs": [
+            "The vote account to validate - must be owned by the Vote program"
+          ]
         },
         {
           "name": "admin",
@@ -131,7 +310,23 @@
               {
                 "kind": "const",
                 "value": [
-                  100, 101, 108, 101, 103, 97, 116, 105, 111, 110, 95, 99, 111, 110, 102, 105, 103
+                  100,
+                  101,
+                  108,
+                  101,
+                  103,
+                  97,
+                  116,
+                  105,
+                  111,
+                  110,
+                  95,
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
                 ]
               }
             ]
@@ -144,6 +339,10 @@
       ],
       "args": [
         {
+          "name": "vote_account",
+          "type": "pubkey"
+        },
+        {
           "name": "status",
           "type": {
             "defined": {
@@ -154,9 +353,153 @@
       ]
     },
     {
+      "name": "force_release_lock",
+      "docs": [
+        "Force release lock (admin only) - for emergency use"
+      ],
+      "discriminator": [
+        127,
+        23,
+        245,
+        174,
+        6,
+        17,
+        18,
+        175
+      ],
+      "accounts": [
+        {
+          "name": "cluster_info",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  99,
+                  108,
+                  117,
+                  115,
+                  116,
+                  101,
+                  114,
+                  95,
+                  105,
+                  110,
+                  102,
+                  111
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "config",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  100,
+                  101,
+                  108,
+                  101,
+                  103,
+                  97,
+                  116,
+                  105,
+                  111,
+                  110,
+                  95,
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "admin",
+          "docs": [
+            "The admin authority that can force release the lock"
+          ],
+          "signer": true
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "initialize_cluster_info",
+      "docs": [
+        "Initialize the cluster info account"
+      ],
+      "discriminator": [
+        177,
+        161,
+        100,
+        157,
+        143,
+        158,
+        48,
+        96
+      ],
+      "accounts": [
+        {
+          "name": "cluster_info",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  99,
+                  108,
+                  117,
+                  115,
+                  116,
+                  101,
+                  114,
+                  95,
+                  105,
+                  110,
+                  102,
+                  111
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": []
+    },
+    {
       "name": "initialize_config",
-      "docs": ["Initialize the delegation config account with all criteria"],
-      "discriminator": [208, 127, 21, 1, 194, 190, 196, 70],
+      "docs": [
+        "Initialize the delegation config account with all criteria"
+      ],
+      "discriminator": [
+        208,
+        127,
+        21,
+        1,
+        194,
+        190,
+        196,
+        70
+      ],
       "accounts": [
         {
           "name": "config",
@@ -166,7 +509,23 @@
               {
                 "kind": "const",
                 "value": [
-                  100, 101, 108, 101, 103, 97, 116, 105, 111, 110, 95, 99, 111, 110, 102, 105, 103
+                  100,
+                  101,
+                  108,
+                  101,
+                  103,
+                  97,
+                  116,
+                  105,
+                  111,
+                  110,
+                  95,
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
                 ]
               }
             ]
@@ -196,11 +555,20 @@
     {
       "name": "reject_validator",
       "docs": [
-        "Reject a validator (admin only)",
+        "Reject a validator (admin or reviewer authority)",
         "",
         "On success the validator will be moved to the `ValidatorStatus::Rejected` state"
       ],
-      "discriminator": [163, 129, 205, 116, 160, 61, 120, 97],
+      "discriminator": [
+        163,
+        129,
+        205,
+        116,
+        160,
+        61,
+        120,
+        97
+      ],
       "accounts": [
         {
           "name": "validator",
@@ -209,11 +577,21 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [118, 97, 108, 105, 100, 97, 116, 111, 114]
+                "value": [
+                  118,
+                  97,
+                  108,
+                  105,
+                  100,
+                  97,
+                  116,
+                  111,
+                  114
+                ]
               },
               {
                 "kind": "account",
-                "path": "validator.identity",
+                "path": "validator.vote_account",
                 "account": "ValidatorInfo"
               }
             ]
@@ -230,11 +608,107 @@
               {
                 "kind": "const",
                 "value": [
-                  100, 101, 108, 101, 103, 97, 116, 105, 111, 110, 95, 99, 111, 110, 102, 105, 103
+                  100,
+                  101,
+                  108,
+                  101,
+                  103,
+                  97,
+                  116,
+                  105,
+                  111,
+                  110,
+                  95,
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
                 ]
               }
             ]
           }
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "release_epoch_lock",
+      "docs": [
+        "Release epoch lock and mark epoch as processed"
+      ],
+      "discriminator": [
+        112,
+        251,
+        176,
+        159,
+        63,
+        206,
+        103,
+        211
+      ],
+      "accounts": [
+        {
+          "name": "cluster_info",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  99,
+                  108,
+                  117,
+                  115,
+                  116,
+                  101,
+                  114,
+                  95,
+                  105,
+                  110,
+                  102,
+                  111
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "config",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  100,
+                  101,
+                  108,
+                  101,
+                  103,
+                  97,
+                  116,
+                  105,
+                  111,
+                  110,
+                  95,
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "bot",
+          "docs": [
+            "The bot authority that can release the lock"
+          ],
+          "signer": true
         }
       ],
       "args": []
@@ -246,7 +720,16 @@
         "",
         "On success the validator account will be deleted and lamports refunded to the admin"
       ],
-      "discriminator": [25, 96, 211, 155, 161, 14, 168, 188],
+      "discriminator": [
+        25,
+        96,
+        211,
+        155,
+        161,
+        14,
+        168,
+        188
+      ],
       "accounts": [
         {
           "name": "validator",
@@ -255,11 +738,21 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [118, 97, 108, 105, 100, 97, 116, 111, 114]
+                "value": [
+                  118,
+                  97,
+                  108,
+                  105,
+                  100,
+                  97,
+                  116,
+                  111,
+                  114
+                ]
               },
               {
                 "kind": "account",
-                "path": "validator.identity",
+                "path": "validator.vote_account",
                 "account": "ValidatorInfo"
               }
             ]
@@ -277,7 +770,23 @@
               {
                 "kind": "const",
                 "value": [
-                  100, 101, 108, 101, 103, 97, 116, 105, 111, 110, 95, 99, 111, 110, 102, 105, 103
+                  100,
+                  101,
+                  108,
+                  101,
+                  103,
+                  97,
+                  116,
+                  105,
+                  111,
+                  110,
+                  95,
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
                 ]
               }
             ]
@@ -287,6 +796,94 @@
       "args": []
     },
     {
+      "name": "set_cluster_epoch",
+      "docs": [
+        "Manually set the last_updated_epoch for cluster info (admin only)",
+        "",
+        "This is an emergency function to manually override the last processed epoch.",
+        "Only the admin authority can call this function."
+      ],
+      "discriminator": [
+        108,
+        191,
+        231,
+        194,
+        3,
+        73,
+        94,
+        75
+      ],
+      "accounts": [
+        {
+          "name": "cluster_info",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  99,
+                  108,
+                  117,
+                  115,
+                  116,
+                  101,
+                  114,
+                  95,
+                  105,
+                  110,
+                  102,
+                  111
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "config",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  100,
+                  101,
+                  108,
+                  101,
+                  103,
+                  97,
+                  116,
+                  105,
+                  111,
+                  110,
+                  95,
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "admin",
+          "docs": [
+            "The admin authority that can manually set cluster epoch"
+          ],
+          "signer": true
+        }
+      ],
+      "args": [
+        {
+          "name": "epoch",
+          "type": "u64"
+        }
+      ]
+    },
+    {
       "name": "transfer_authority",
       "docs": [
         "Transfer admin authority to a new account",
@@ -294,7 +891,16 @@
         "This is an irreversible operation. The current admin transfers",
         "control to a new admin authority."
       ],
-      "discriminator": [48, 169, 76, 72, 229, 180, 55, 161],
+      "discriminator": [
+        48,
+        169,
+        76,
+        72,
+        229,
+        180,
+        55,
+        161
+      ],
       "accounts": [
         {
           "name": "config",
@@ -304,7 +910,23 @@
               {
                 "kind": "const",
                 "value": [
-                  100, 101, 108, 101, 103, 97, 116, 105, 111, 110, 95, 99, 111, 110, 102, 105, 103
+                  100,
+                  101,
+                  108,
+                  101,
+                  103,
+                  97,
+                  116,
+                  105,
+                  111,
+                  110,
+                  95,
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
                 ]
               }
             ]
@@ -312,9 +934,13 @@
         },
         {
           "name": "authority",
-          "docs": ["The current admin authority that must sign this transaction"],
+          "docs": [
+            "The current admin authority that must sign this transaction"
+          ],
           "signer": true,
-          "relations": ["config"]
+          "relations": [
+            "config"
+          ]
         }
       ],
       "args": [
@@ -331,7 +957,16 @@
         "",
         "This allows the admin to update the bot authority that can update validator criteria status"
       ],
-      "discriminator": [109, 185, 206, 131, 96, 208, 252, 197],
+      "discriminator": [
+        109,
+        185,
+        206,
+        131,
+        96,
+        208,
+        252,
+        197
+      ],
       "accounts": [
         {
           "name": "config",
@@ -341,7 +976,23 @@
               {
                 "kind": "const",
                 "value": [
-                  100, 101, 108, 101, 103, 97, 116, 105, 111, 110, 95, 99, 111, 110, 102, 105, 103
+                  100,
+                  101,
+                  108,
+                  101,
+                  103,
+                  97,
+                  116,
+                  105,
+                  111,
+                  110,
+                  95,
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
                 ]
               }
             ]
@@ -349,9 +1000,13 @@
         },
         {
           "name": "authority",
-          "docs": ["The current admin authority that must sign this transaction"],
+          "docs": [
+            "The current admin authority that must sign this transaction"
+          ],
           "signer": true,
-          "relations": ["config"]
+          "relations": [
+            "config"
+          ]
         }
       ],
       "args": [
@@ -362,9 +1017,100 @@
       ]
     },
     {
+      "name": "update_cluster_info",
+      "docs": [
+        "Update cluster info last_updated_epoch (bot authority only)"
+      ],
+      "discriminator": [
+        242,
+        247,
+        157,
+        205,
+        183,
+        77,
+        136,
+        165
+      ],
+      "accounts": [
+        {
+          "name": "cluster_info",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  99,
+                  108,
+                  117,
+                  115,
+                  116,
+                  101,
+                  114,
+                  95,
+                  105,
+                  110,
+                  102,
+                  111
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "config",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  100,
+                  101,
+                  108,
+                  101,
+                  103,
+                  97,
+                  116,
+                  105,
+                  111,
+                  110,
+                  95,
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "bot",
+          "docs": [
+            "The bot authority that can update cluster info"
+          ],
+          "signer": true
+        }
+      ],
+      "args": []
+    },
+    {
       "name": "update_config",
-      "docs": ["Update delegation config parameters - all fields are optional"],
-      "discriminator": [29, 158, 252, 191, 10, 83, 219, 99],
+      "docs": [
+        "Update delegation config parameters - all fields are optional"
+      ],
+      "discriminator": [
+        29,
+        158,
+        252,
+        191,
+        10,
+        83,
+        219,
+        99
+      ],
       "accounts": [
         {
           "name": "config",
@@ -374,7 +1120,23 @@
               {
                 "kind": "const",
                 "value": [
-                  100, 101, 108, 101, 103, 97, 116, 105, 111, 110, 95, 99, 111, 110, 102, 105, 103
+                  100,
+                  101,
+                  108,
+                  101,
+                  103,
+                  97,
+                  116,
+                  105,
+                  111,
+                  110,
+                  95,
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
                 ]
               }
             ]
@@ -383,7 +1145,9 @@
         {
           "name": "authority",
           "signer": true,
-          "relations": ["config"]
+          "relations": [
+            "config"
+          ]
         }
       ],
       "args": [
@@ -398,9 +1162,90 @@
       ]
     },
     {
-      "name": "update_validator_criteria",
-      "docs": ["Update validator criteria status"],
-      "discriminator": [242, 111, 245, 169, 247, 54, 56, 155],
+      "name": "update_reviewer_authority",
+      "docs": [
+        "Update reviewer authority",
+        "",
+        "This allows the admin to update the reviewer authority that can change validator",
+        "status (approve, reject, update_validator_status) alongside the admin authority.",
+        "Setting it to the default pubkey disables the reviewer role."
+      ],
+      "discriminator": [
+        203,
+        154,
+        30,
+        205,
+        103,
+        132,
+        85,
+        15
+      ],
+      "accounts": [
+        {
+          "name": "config",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  100,
+                  101,
+                  108,
+                  101,
+                  103,
+                  97,
+                  116,
+                  105,
+                  111,
+                  110,
+                  95,
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "authority",
+          "docs": [
+            "The current admin authority that must sign this transaction"
+          ],
+          "signer": true,
+          "relations": [
+            "config"
+          ]
+        }
+      ],
+      "args": [
+        {
+          "name": "new_reviewer_authority",
+          "type": "pubkey"
+        }
+      ]
+    },
+    {
+      "name": "update_stake_change_epoch",
+      "docs": [
+        "Update validator's last stake change epoch (bot authority only)",
+        "",
+        "This should be called when a validator's stake is increased or decreased"
+      ],
+      "discriminator": [
+        185,
+        189,
+        71,
+        209,
+        144,
+        190,
+        232,
+        22
+      ],
       "accounts": [
         {
           "name": "validator",
@@ -409,11 +1254,103 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [118, 97, 108, 105, 100, 97, 116, 111, 114]
+                "value": [
+                  118,
+                  97,
+                  108,
+                  105,
+                  100,
+                  97,
+                  116,
+                  111,
+                  114
+                ]
               },
               {
                 "kind": "account",
-                "path": "validator.identity",
+                "path": "validator.vote_account",
+                "account": "ValidatorInfo"
+              }
+            ]
+          }
+        },
+        {
+          "name": "config",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  100,
+                  101,
+                  108,
+                  101,
+                  103,
+                  97,
+                  116,
+                  105,
+                  111,
+                  110,
+                  95,
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "bot",
+          "docs": [
+            "The bot authority that can update stake change epoch"
+          ],
+          "signer": true
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "update_validator_criteria",
+      "docs": [
+        "Update validator criteria status for current epoch"
+      ],
+      "discriminator": [
+        242,
+        111,
+        245,
+        169,
+        247,
+        54,
+        56,
+        155
+      ],
+      "accounts": [
+        {
+          "name": "validator",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  118,
+                  97,
+                  108,
+                  105,
+                  100,
+                  97,
+                  116,
+                  111,
+                  114
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "validator.vote_account",
                 "account": "ValidatorInfo"
               }
             ]
@@ -421,7 +1358,9 @@
         },
         {
           "name": "bot",
-          "docs": ["The bot authority that must match the config bot_authority"],
+          "docs": [
+            "The bot authority that must match the config bot_authority"
+          ],
           "signer": true
         },
         {
@@ -431,7 +1370,23 @@
               {
                 "kind": "const",
                 "value": [
-                  100, 101, 108, 101, 103, 97, 116, 105, 111, 110, 95, 99, 111, 110, 102, 105, 103
+                  100,
+                  101,
+                  108,
+                  101,
+                  103,
+                  97,
+                  116,
+                  105,
+                  111,
+                  110,
+                  95,
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
                 ]
               }
             ]
@@ -452,13 +1407,23 @@
       ]
     },
     {
-      "name": "update_validator_status",
+      "name": "update_validator_multiplier",
       "docs": [
-        "Rewrite a validator account to the provided state (admin only)",
+        "Update a validator's stake multiplier (admin only)",
         "",
-        "Bypass the normal workflow and set validator to any state"
+        "The multiplier is specified in basis points (10000 = 100%)",
+        "Can be set to 0 to effectively disable staking for a validator"
       ],
-      "discriminator": [251, 40, 229, 66, 218, 176, 24, 229],
+      "discriminator": [
+        145,
+        35,
+        177,
+        219,
+        111,
+        220,
+        48,
+        122
+      ],
       "accounts": [
         {
           "name": "validator",
@@ -467,11 +1432,110 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [118, 97, 108, 105, 100, 97, 116, 111, 114]
+                "value": [
+                  118,
+                  97,
+                  108,
+                  105,
+                  100,
+                  97,
+                  116,
+                  111,
+                  114
+                ]
               },
               {
                 "kind": "account",
-                "path": "validator.identity",
+                "path": "validator.vote_account",
+                "account": "ValidatorInfo"
+              }
+            ]
+          }
+        },
+        {
+          "name": "config",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  100,
+                  101,
+                  108,
+                  101,
+                  103,
+                  97,
+                  116,
+                  105,
+                  111,
+                  110,
+                  95,
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "signer",
+          "docs": [
+            "The signer (either admin authority or bot authority)"
+          ],
+          "signer": true
+        }
+      ],
+      "args": [
+        {
+          "name": "stake_multiplier_bps",
+          "type": "u16"
+        }
+      ]
+    },
+    {
+      "name": "update_validator_status",
+      "docs": [
+        "Rewrite a validator account to the provided state (admin or reviewer authority)",
+        "",
+        "Bypass the normal workflow and set validator to any state"
+      ],
+      "discriminator": [
+        251,
+        40,
+        229,
+        66,
+        218,
+        176,
+        24,
+        229
+      ],
+      "accounts": [
+        {
+          "name": "validator",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  118,
+                  97,
+                  108,
+                  105,
+                  100,
+                  97,
+                  116,
+                  111,
+                  114
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "validator.vote_account",
                 "account": "ValidatorInfo"
               }
             ]
@@ -488,7 +1552,23 @@
               {
                 "kind": "const",
                 "value": [
-                  100, 101, 108, 101, 103, 97, 116, 105, 111, 110, 95, 99, 111, 110, 102, 105, 103
+                  100,
+                  101,
+                  108,
+                  101,
+                  103,
+                  97,
+                  116,
+                  105,
+                  111,
+                  110,
+                  95,
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
                 ]
               }
             ]
@@ -514,7 +1594,16 @@
         "Validators can remove themselves by calling this instruction.",
         "On success the validator account will be deleted and lamports refunded"
       ],
-      "discriminator": [73, 175, 146, 162, 146, 174, 152, 16],
+      "discriminator": [
+        73,
+        175,
+        146,
+        162,
+        146,
+        174,
+        152,
+        16
+      ],
       "accounts": [
         {
           "name": "validator",
@@ -523,18 +1612,37 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [118, 97, 108, 105, 100, 97, 116, 111, 114]
+                "value": [
+                  118,
+                  97,
+                  108,
+                  105,
+                  100,
+                  97,
+                  116,
+                  111,
+                  114
+                ]
               },
               {
                 "kind": "account",
-                "path": "validator.identity",
+                "path": "validator.vote_account",
                 "account": "ValidatorInfo"
               }
             ]
           }
         },
         {
-          "name": "identity",
+          "name": "vote",
+          "docs": [
+            "The vote account being withdrawn"
+          ]
+        },
+        {
+          "name": "signer",
+          "docs": [
+            "The signer who is withdrawing (must have authority over the vote account)"
+          ],
           "signer": true
         },
         {
@@ -547,12 +1655,43 @@
   ],
   "accounts": [
     {
+      "name": "ClusterInfo",
+      "discriminator": [
+        166,
+        104,
+        254,
+        59,
+        225,
+        162,
+        221,
+        196
+      ]
+    },
+    {
       "name": "DelegationConfig",
-      "discriminator": [14, 156, 133, 17, 100, 34, 0, 49]
+      "discriminator": [
+        14,
+        156,
+        133,
+        17,
+        100,
+        34,
+        0,
+        49
+      ]
     },
     {
       "name": "ValidatorInfo",
-      "discriminator": [121, 15, 32, 151, 174, 70, 186, 250]
+      "discriminator": [
+        121,
+        15,
+        32,
+        151,
+        174,
+        70,
+        186,
+        250
+      ]
     }
   ],
   "errors": [
@@ -640,116 +1779,251 @@
       "code": 6016,
       "name": "InvalidConfigParameter",
       "msg": "Invalid configuration parameter"
+    },
+    {
+      "code": 6017,
+      "name": "InvalidVoteAccount",
+      "msg": "Invalid vote account - must be a valid vote account owned by the Vote program"
+    },
+    {
+      "code": 6018,
+      "name": "EpochCurrentlyLocked",
+      "msg": "Epoch is currently locked - another bot instance is processing"
+    },
+    {
+      "code": 6019,
+      "name": "EpochAlreadyProcessed",
+      "msg": "Epoch has already been processed"
+    },
+    {
+      "code": 6020,
+      "name": "NotLockOwner",
+      "msg": "Not the lock owner - cannot release lock"
     }
   ],
   "types": [
     {
-      "name": "DelegationConfig",
-      "docs": ["Global delegation configuration parameters"],
+      "name": "ClusterInfo",
+      "docs": [
+        "Cluster-wide information for tracking delegation bot runs"
+      ],
       "type": {
         "kind": "struct",
         "fields": [
           {
             "name": "version",
-            "docs": ["Version of this account structure"],
+            "docs": [
+              "Version of this account structure"
+            ],
             "type": "u8"
-          },
-          {
-            "name": "authority",
-            "docs": ["Authority that can update this config"],
-            "type": "pubkey"
-          },
-          {
-            "name": "max_commission_percent",
-            "docs": ["Maximum commission percentage allowed (0-100)"],
-            "type": "u8"
-          },
-          {
-            "name": "min_self_stake",
-            "docs": ["Minimum self-stake required from validators (in lamports)"],
-            "type": "u64"
-          },
-          {
-            "name": "max_total_stake",
-            "docs": ["Maximum total stake per validator (in lamports)"],
-            "type": "u64"
-          },
-          {
-            "name": "max_validator_stake_pct",
-            "docs": ["Maximum percentage of total network stake a validator can have (0-100)"],
-            "type": "u8"
-          },
-          {
-            "name": "skip_rate_tolerance_pct",
-            "docs": ["Skip rate tolerance percentage above cluster average (0-100)"],
-            "type": "u8"
-          },
-          {
-            "name": "vote_credits_threshold_pct",
-            "docs": ["Vote credits threshold as percentage of cluster average (0-100)"],
-            "type": "u8"
-          },
-          {
-            "name": "min_validator_version",
-            "docs": ["Minimum Validator version required (packed as major.minor.patch)"],
-            "type": "u32"
-          },
-          {
-            "name": "reserve_stake_pct",
-            "docs": ["Reserve stake percentage to maintain (0-100)"],
-            "type": "u8"
-          },
-          {
-            "name": "max_validators",
-            "docs": ["Maximum number of validators to delegate to"],
-            "type": "u32"
-          },
-          {
-            "name": "emergency_pause",
-            "docs": ["Emergency pause flag"],
-            "type": "bool"
           },
           {
             "name": "last_updated_epoch",
-            "docs": ["Last epoch when this config was updated"],
+            "docs": [
+              "Last epoch when the cluster was fully processed by the bot"
+            ],
             "type": "u64"
           },
           {
             "name": "bump",
-            "docs": ["Bump seed for PDA generation"],
+            "docs": [
+              "Bump seed for PDA generation"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "locked_until_slot",
+            "docs": [
+              "Slot until which the lock is held (0 if not locked)",
+              "When acquiring lock, set to current_slot + timeout_duration"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "_reserved",
+            "docs": [
+              "Reserved space for future use (512 - 8 = 504)"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                504
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "DelegationConfig",
+      "docs": [
+        "Global delegation configuration parameters"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "version",
+            "docs": [
+              "Version of this account structure"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "authority",
+            "docs": [
+              "Authority that can update this config"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "max_commission_percent",
+            "docs": [
+              "Maximum commission percentage allowed (0-100)"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "min_self_stake",
+            "docs": [
+              "Minimum self-stake required from validators (in lamports)"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "max_total_stake",
+            "docs": [
+              "Maximum total stake per validator (in lamports)"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "max_validator_stake_pct",
+            "docs": [
+              "Maximum percentage of total network stake a validator can have (0-100)"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "skip_rate_tolerance_pct",
+            "docs": [
+              "Skip rate tolerance percentage above cluster average (0-100)"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "vote_credits_threshold_pct",
+            "docs": [
+              "Vote credits threshold as percentage of cluster average (0-100)"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "min_validator_version",
+            "docs": [
+              "Minimum Validator version required (packed as major.minor.patch)"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "reserve_stake_pct",
+            "docs": [
+              "Reserve stake percentage to maintain (0-100)"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "max_validators",
+            "docs": [
+              "Maximum number of validators to delegate to"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "emergency_pause",
+            "docs": [
+              "Emergency pause flag"
+            ],
+            "type": "bool"
+          },
+          {
+            "name": "last_updated_epoch",
+            "docs": [
+              "Last epoch when this config was updated"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "bump",
+            "docs": [
+              "Bump seed for PDA generation"
+            ],
             "type": "u8"
           },
           {
             "name": "stake_matching_cap",
-            "docs": ["Maximum stake to match 1:1 with external stake (in lamports)"],
+            "docs": [
+              "Maximum stake to match 1:1 with external stake (in lamports)"
+            ],
             "type": "u64"
           },
           {
             "name": "base_allocation_weight",
-            "docs": ["Percentage of available stake (after reserve) for base allocation (0-100)"],
+            "docs": [
+              "Percentage of available stake (after reserve) for base allocation (0-100)"
+            ],
             "type": "u8"
           },
           {
             "name": "match_allocation_weight",
-            "docs": ["Percentage of available stake (after reserve) for match allocation (0-100)"],
+            "docs": [
+              "Percentage of available stake (after reserve) for match allocation (0-100)"
+            ],
             "type": "u8"
           },
           {
             "name": "min_stake_adjustment_pct",
-            "docs": ["Minimum stake adjustment percentage required to trigger rebalancing (0-100)"],
+            "docs": [
+              "Minimum stake adjustment percentage required to trigger rebalancing (0-100)"
+            ],
             "type": "u8"
           },
           {
             "name": "bot_authority",
-            "docs": ["Bot authority that can update validator criteria status (added in v3)"],
+            "docs": [
+              "Bot authority that can update validator criteria status (added in v3)"
+            ],
             "type": "pubkey"
+          },
+          {
+            "name": "reviewer_authority",
+            "docs": [
+              "Reviewer authority that can change validator status alongside the admin authority",
+              "(approve, reject and update_validator_status). Carved out of `_reserved` so the",
+              "account size is unchanged for already deployed configs."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "_reserved",
+            "docs": [
+              "Reserved space for future use"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                480
+              ]
+            }
           }
         ]
       }
     },
     {
       "name": "DelegationCriterion",
-      "docs": ["Delegation criteria that a validator can fail"],
+      "docs": [
+        "Delegation criteria that a validator can fail"
+      ],
       "type": {
         "kind": "enum",
         "variants": [
@@ -788,7 +2062,9 @@
     },
     {
       "name": "UpdateConfigParams",
-      "docs": ["Parameters for updating delegation config - all fields are optional"],
+      "docs": [
+        "Parameters for updating delegation config - all fields are optional"
+      ],
       "type": {
         "kind": "struct",
         "fields": [
@@ -881,18 +2157,31 @@
     },
     {
       "name": "ValidatorInfo",
-      "docs": ["Information about a single validator in the delegation program"],
+      "docs": [
+        "Information about a single validator in the delegation program"
+      ],
       "type": {
         "kind": "struct",
         "fields": [
           {
-            "name": "identity",
-            "docs": ["The validator's identity account public key (used for PDA derivation)"],
+            "name": "version",
+            "docs": [
+              "Version of this account structure"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "vote_account",
+            "docs": [
+              "The validator's vote account public key (used for PDA derivation)"
+            ],
             "type": "pubkey"
           },
           {
             "name": "status",
-            "docs": ["Current status of the validator"],
+            "docs": [
+              "Current status of the validator"
+            ],
             "type": {
               "defined": {
                 "name": "ValidatorStatus"
@@ -901,17 +2190,23 @@
           },
           {
             "name": "last_updated_epoch",
-            "docs": ["Last epoch when this validator's information was updated"],
+            "docs": [
+              "Last epoch when this validator's information was updated"
+            ],
             "type": "u64"
           },
           {
             "name": "bump",
-            "docs": ["Bump seed for PDA generation"],
+            "docs": [
+              "Bump seed for PDA generation"
+            ],
             "type": "u8"
           },
           {
             "name": "failing_criteria",
-            "docs": ["Vector of criteria this validator is currently failing"],
+            "docs": [
+              "Vector of criteria this validator is currently failing"
+            ],
             "type": {
               "vec": {
                 "defined": {
@@ -919,13 +2214,42 @@
                 }
               }
             }
+          },
+          {
+            "name": "stake_multiplier_bps",
+            "docs": [
+              "Stake multiplier in basis points (10000 = 100%, 5000 = 50%, 20000 = 200%)",
+              "Used for stake warm-up and other delegation adjustments"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "last_stake_change_epoch",
+            "docs": [
+              "Last epoch when this validator's stake was increased or decreased"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "_reserved",
+            "docs": [
+              "Reserved space for future use"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                502
+              ]
+            }
           }
         ]
       }
     },
     {
       "name": "ValidatorStatus",
-      "docs": ["Validator status in the delegation program"],
+      "docs": [
+        "Validator status in the delegation program"
+      ],
       "type": {
         "kind": "enum",
         "variants": [

--- a/src/lib/registry/core.ts
+++ b/src/lib/registry/core.ts
@@ -57,6 +57,18 @@ interface RegisteredProgram {
 }
 
 /**
+ * Normalize an instruction name for registry lookups.
+ *
+ * The decoder emits PascalCase names built from the IDL (`update_config` ->
+ * `UpdateConfig`), while registrations are written in whatever style the IDL
+ * uses. Stripping separators and casing lets `update_config`, `updateConfig`
+ * and `Update Config` all resolve to the same entry.
+ */
+function normalizeInstructionName(name: string): string {
+  return name.replace(/[^a-zA-Z0-9]/g, '').toLowerCase();
+}
+
+/**
  * Central registry for all program metadata
  */
 class ProgramRegistry {
@@ -94,7 +106,7 @@ class ProgramRegistry {
     // Process instruction configurations
     if (config.instructions) {
       for (const [instructionName, instructionConfig] of Object.entries(config.instructions)) {
-        program.instructions.set(instructionName.toLowerCase(), {
+        program.instructions.set(normalizeInstructionName(instructionName), {
           ...instructionConfig,
           tags: instructionConfig.tags
             ? Array.isArray(instructionConfig.tags)
@@ -142,7 +154,7 @@ class ProgramRegistry {
     const program = this.programs.get(programId);
     if (!program) return undefined;
 
-    const instruction = program.instructions.get(instructionName.toLowerCase());
+    const instruction = program.instructions.get(normalizeInstructionName(instructionName));
     return instruction?.summary;
   }
 
@@ -161,7 +173,9 @@ class ProgramRegistry {
     }
 
     // Add instruction-specific tags
-    const instructionConfig = program.instructions.get(instruction.instructionName.toLowerCase());
+    const instructionConfig = program.instructions.get(
+      normalizeInstructionName(instruction.instructionName)
+    );
     if (instructionConfig?.tags) {
       tags.push(...instructionConfig.tags);
     }

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -43,6 +43,30 @@ import {
   BridgeMigrateTokenRegistrySummary,
   BridgeTransferMintAuthoritySummary,
 } from './components/instructions/summaries/warp-bridge';
+import {
+  DelegationUpdateConfigSummary,
+  DelegationCreateValidatorSummary,
+  DelegationApplyValidatorSummary,
+  DelegationApproveValidatorSummary,
+  DelegationRejectValidatorSummary,
+  DelegationRemoveValidatorSummary,
+  DelegationWithdrawValidatorSummary,
+  DelegationUpdateValidatorStatusSummary,
+  DelegationUpdateValidatorCriteriaSummary,
+  DelegationUpdateValidatorMultiplierSummary,
+  DelegationUpdateStakeChangeEpochSummary,
+  DelegationInitializeConfigSummary,
+  DelegationTransferAuthoritySummary,
+  DelegationUpdateBotAuthoritySummary,
+  DelegationUpdateReviewerAuthoritySummary,
+  DelegationInitializeClusterInfoSummary,
+  DelegationUpdateClusterInfoSummary,
+  DelegationSetClusterEpochSummary,
+  DelegationAcquireEpochLockSummary,
+  DelegationReleaseEpochLockSummary,
+  DelegationForceReleaseLockSummary,
+} from './components/instructions/summaries/delegation';
+import { DELEGATION_PROGRAM_ID_LIST } from './lib/delegation/accounts';
 
 // Import IDLs
 import squadsV4Idl from './lib/idls/squads-v4.json';
@@ -225,28 +249,103 @@ registry.register({
 // ============================================
 // Delegation Program
 // ============================================
+// Registered for every network the UI serves — mainnet, testnet and localnet
+// each deploy the program under a different ID.
 registry.register({
-  programId: 'X1DPvnLXekvd6EtDsPVqahzhziKx3Zj1z8WkD93xebg',
+  programId: DELEGATION_PROGRAM_ID_LIST,
   name: 'Delegation Program',
   idl: delegationProgramIdl,
   instructions: {
-    UpdateConfig: {
+    // Global configuration
+    update_config: {
+      summary: DelegationUpdateConfigSummary,
       tags: { label: 'Update Config', color: 'blue', variant: 'subtle' },
     },
-    CreateValidator: {
+    initialize_config: {
+      summary: DelegationInitializeConfigSummary,
+      tags: { label: 'Initialize Config', color: 'purple', variant: 'subtle' },
+    },
+
+    // Validator lifecycle
+    create_validator: {
+      summary: DelegationCreateValidatorSummary,
       tags: { label: 'Create Validator', color: 'blue', variant: 'subtle' },
     },
-    RemoveValidator: {
-      tags: { label: 'Remove Validator', color: 'blue', variant: 'subtle' },
+    apply_validator: {
+      summary: DelegationApplyValidatorSummary,
+      tags: { label: 'Apply Validator', color: 'blue', variant: 'subtle' },
     },
-    ApproveValidator: {
-      tags: { label: 'Approve Validator', color: 'blue', variant: 'subtle' },
+    approve_validator: {
+      summary: DelegationApproveValidatorSummary,
+      tags: { label: 'Approve Validator', color: 'green', variant: 'subtle' },
     },
-    RejectValidator: {
+    reject_validator: {
+      summary: DelegationRejectValidatorSummary,
       tags: { label: 'Reject Validator', color: 'red', variant: 'subtle' },
     },
-    UpdateValidatorStatus: {
+    remove_validator: {
+      summary: DelegationRemoveValidatorSummary,
+      tags: { label: 'Remove Validator', color: 'red', variant: 'subtle' },
+    },
+    withdraw_validator: {
+      summary: DelegationWithdrawValidatorSummary,
+      tags: { label: 'Withdraw Validator', color: 'orange', variant: 'subtle' },
+    },
+    update_validator_status: {
+      summary: DelegationUpdateValidatorStatusSummary,
       tags: { label: 'Update Validator Status', color: 'blue', variant: 'subtle' },
+    },
+    update_validator_criteria: {
+      summary: DelegationUpdateValidatorCriteriaSummary,
+      tags: { label: 'Update Criteria', color: 'amber', variant: 'subtle' },
+    },
+    update_validator_multiplier: {
+      summary: DelegationUpdateValidatorMultiplierSummary,
+      tags: { label: 'Stake Multiplier', color: 'purple', variant: 'subtle' },
+    },
+    update_stake_change_epoch: {
+      summary: DelegationUpdateStakeChangeEpochSummary,
+      tags: { label: 'Stake Change Epoch', color: 'gray', variant: 'subtle' },
+    },
+
+    // Authorities
+    transfer_authority: {
+      summary: DelegationTransferAuthoritySummary,
+      tags: { label: 'Transfer Admin', color: 'red', variant: 'subtle' },
+    },
+    update_bot_authority: {
+      summary: DelegationUpdateBotAuthoritySummary,
+      tags: { label: 'Update Bot Authority', color: 'purple', variant: 'subtle' },
+    },
+    update_reviewer_authority: {
+      summary: DelegationUpdateReviewerAuthoritySummary,
+      tags: { label: 'Update Reviewer', color: 'blue', variant: 'subtle' },
+    },
+
+    // Cluster state and the bot's epoch lock
+    initialize_cluster_info: {
+      summary: DelegationInitializeClusterInfoSummary,
+      tags: { label: 'Initialize Cluster', color: 'purple', variant: 'subtle' },
+    },
+    update_cluster_info: {
+      summary: DelegationUpdateClusterInfoSummary,
+      tags: { label: 'Update Cluster', color: 'gray', variant: 'subtle' },
+    },
+    set_cluster_epoch: {
+      summary: DelegationSetClusterEpochSummary,
+      tags: { label: 'Set Cluster Epoch', color: 'amber', variant: 'subtle' },
+    },
+    acquire_epoch_lock: {
+      summary: DelegationAcquireEpochLockSummary,
+      tags: { label: 'Acquire Epoch Lock', color: 'gray', variant: 'subtle' },
+    },
+    release_epoch_lock: {
+      summary: DelegationReleaseEpochLockSummary,
+      tags: { label: 'Release Epoch Lock', color: 'green', variant: 'subtle' },
+    },
+    force_release_lock: {
+      summary: DelegationForceReleaseLockSummary,
+      tags: { label: 'Force Release Lock', color: 'amber', variant: 'subtle' },
     },
   },
 });


### PR DESCRIPTION
Delegation program proposals rendered as undecoded instructions on mainnet and, where they did decode, as a raw wall of arguments. This adds a summary for each of the program's 21 instructions.

Example: [proposal #119](https://multisig.mainnet.x1.xyz/89PksQjFwnpUNu3Rc3GLdnZnBCbUNLNruDHcjdU1zPfs/transactions/9md8sVK9GPeRKBnuM3X5g4c5Gcm4nA3Kn1CFNX5TU1HM), which raises the minimum self-stake to 5,000 XNT, now reads:

> ⚙️ **Update Delegation Config** — *1 of 14 submitted parameters change*
> **Min self-stake:** ~~3,000 XNT~~ → **5,000 XNT** (+67%)
> *Stake a validator must put up itself to qualify for delegation*
> ▸ 13 parameters resubmitted unchanged

## What this does

The bot resubmits every parameter on each `update_config` proposal, so the raw arguments mostly restate the current config. The summary fetches the live `DelegationConfig` and leads with what actually changes, collapsing the rest — without that diff a reviewer can't tell which of the 14 values moved.

The other summaries do the same wherever a current value can be read from chain: validator status transitions (`Approved → Rejected`), authority handovers showing the current holder, stake multipliers, cluster epochs. Validator instructions carry no arguments, so the `validator` PDA is resolved to a vote account and gossip name.

Lamports render as XNT, packed versions as `3.1.14`, criteria enums as plain language. Each row carries a one-line explanation of what the parameter controls.

## Bugs fixed along the way

Both blocked any of this from working:

1. **Only the testnet program ID was registered** (`X1DPvnLX…`). Mainnet is `x1Dp8D2X…`, localnet is a third ID — so no delegation instruction decoded on mainnet at all. All three are now registered together.
2. **Registry summary lookups could never match snake_case names.** The decoder emits `UpdateConfig` and lookups lowercase to `updateconfig`, but a registration keyed on `update_config` stayed `update_config`. Lookups now strip separators on both sides, which also restores the 16 existing warp-bridge summaries — none of which were rendering.

The bundled IDL was also stale (12 instructions, localnet address) and is refreshed from the delegation program SDK to the current 21 with the mainnet address.

## Structure

Config field metadata lives in one table (`src/lib/delegation/configFields.ts`), so a new config parameter needs an entry there plus an IDL refresh — no component changes.

## Testing

- Loaded proposal #119 in the running app against X1 mainnet; renders as above with zero console errors.
- Verified every summary's argument and account names against the IDL, and confirmed `ValidatorInfo` / `ClusterInfo` decode against live mainnet accounts (3,323 validator records).
- Rendered all 21 summaries through a temporary route to catch render-time crashes, then removed it.
- `tsc --noEmit` clean; `yarn build:mainnet` succeeds.