### PR TITLE
feat: decode the delegation repeat-removal penalty

### DIFF
--- a/src/components/instructions/summaries/delegation/ValidatorSummaries.tsx
+++ b/src/components/instructions/summaries/delegation/ValidatorSummaries.tsx
@@ -17,7 +17,8 @@ import {
   ValueChange,
   accountByName,
 } from './shared';
-import { useDelegationValidator } from './hooks';
+import { useDelegationConfig, useDelegationValidator } from './hooks';
+import { DelegationConfigAccount } from '@/lib/delegation/accounts';
 
 /** Describe a `ValidatorStatus` enum value, falling back to the raw variant. */
 function describeStatus(value: unknown): { label: string; description?: string } {
@@ -326,6 +327,126 @@ export const DelegationUpdateValidatorMultiplierSummary: React.FC<InstructionSum
             )
           }
         />
+        {signer && <AddressWithButtons address={signer} label="Signer" />}
+      </DetailBlock>
+    </SummaryShell>
+  );
+};
+
+/**
+ * Translate a raw removal score into the terms an approver needs to judge it.
+ *
+ * The score is penalty points, not a removal count: a removal adds
+ * `strike_decay_epochs` points and each eligible epoch works one off. The raw
+ * number alone says nothing about what the proposal does to the validator, so
+ * derive the removal count and the delegation ceiling it imposes.
+ */
+function describeRemovalScore(
+  score: number | null,
+  config: DelegationConfigAccount | null
+): { removals: number; capBps: number } | null {
+  if (score === null || !config) return null;
+
+  const decayEpochs = toNumber(config.strike_decay_epochs);
+  const penaltyBps = toNumber(config.strike_penalty_bps);
+  const minCapBps = toNumber(config.strike_min_cap_bps);
+  if (!decayEpochs || !penaltyBps || minCapBps === null) return null;
+
+  const removals = Math.floor(score / decayEpochs);
+  return {
+    removals,
+    capBps: Math.max(10000 - removals * penaltyBps, minCapBps),
+  };
+}
+
+/**
+ * `update_validator_removal_score` — records or works off the repeat-removal
+ * penalty. Raising it lowers the validator's delegation ceiling and slows its
+ * ramp back up; the bot lowers it by one for every epoch the validator stays
+ * eligible.
+ */
+export const DelegationUpdateValidatorRemovalScoreSummary: React.FC<InstructionSummaryProps> = ({
+  instruction,
+  connection,
+}) => {
+  const { voteAccount, validatorPda, info } = useDelegationValidator(instruction, connection);
+  const { config } = useDelegationConfig(instruction, connection);
+  const signer = accountByName(instruction, 'signer', 2);
+
+  const newScore = toNumber(instruction.args?.removal_score);
+  const currentScore = info ? toNumber(info.removal_score) : null;
+  const changed = currentScore !== null && newScore !== null && currentScore !== newScore;
+  const increased = currentScore !== null && newScore !== null && newScore > currentScore;
+
+  const next = describeRemovalScore(newScore, config);
+  const current = describeRemovalScore(currentScore, config);
+
+  return (
+    <SummaryShell
+      icon="⛔"
+      title="Update Repeat Removal Penalty"
+      subtitle={
+        newScore === null
+          ? "Adjusts this validator's repeat-removal penalty"
+          : newScore === 0
+            ? 'Clears the penalty and restores full delegation eligibility'
+            : increased
+              ? 'Penalises this validator for being removed again for poor performance'
+              : "Works off part of this validator's repeat-removal penalty"
+      }
+      tone={increased ? 'red' : 'amber'}
+    >
+      <DetailBlock>
+        <ValidatorTarget voteAccount={voteAccount} validatorPda={validatorPda} />
+        <Field
+          label="Penalty points"
+          hint="Also the number of good epochs left before the penalty clears"
+          value={
+            changed ? (
+              <ValueChange
+                from={currentScore?.toLocaleString() ?? '—'}
+                to={newScore?.toLocaleString() ?? '—'}
+                tone={increased ? 'red' : 'amber'}
+              />
+            ) : (
+              (newScore?.toLocaleString() ?? '—')
+            )
+          }
+        />
+        {next && (
+          <>
+            <Field
+              label="Recent removals"
+              hint="Penalty points divided by the configured decay period"
+              value={
+                current && current.removals !== next.removals ? (
+                  <ValueChange
+                    from={String(current.removals)}
+                    to={String(next.removals)}
+                    tone={increased ? 'red' : 'amber'}
+                  />
+                ) : (
+                  String(next.removals)
+                )
+              }
+            />
+            <Field
+              label="Delegation ceiling"
+              hint="Most stake this validator may receive while the penalty stands"
+              value={
+                current && current.capBps !== next.capBps ? (
+                  <ValueChange
+                    from={formatBasisPoints(current.capBps)}
+                    to={formatBasisPoints(next.capBps)}
+                    tone={increased ? 'red' : 'amber'}
+                  />
+                ) : (
+                  formatBasisPoints(next.capBps)
+                )
+              }
+            />
+          </>
+        )}
         {signer && <AddressWithButtons address={signer} label="Signer" />}
       </DetailBlock>
     </SummaryShell>

--- a/src/components/instructions/summaries/delegation/index.ts
+++ b/src/components/instructions/summaries/delegation/index.ts
@@ -18,6 +18,7 @@ export {
   DelegationUpdateValidatorStatusSummary,
   DelegationUpdateValidatorCriteriaSummary,
   DelegationUpdateValidatorMultiplierSummary,
+  DelegationUpdateValidatorRemovalScoreSummary,
   DelegationUpdateStakeChangeEpochSummary,
 } from './ValidatorSummaries';
 

--- a/src/lib/delegation/accounts.ts
+++ b/src/lib/delegation/accounts.ts
@@ -75,6 +75,9 @@ export interface DelegationConfigAccount {
   min_stake_adjustment_pct: number;
   bot_authority: PublicKey;
   reviewer_authority: PublicKey;
+  strike_penalty_bps: number;
+  strike_min_cap_bps: number;
+  strike_decay_epochs: number;
 }
 
 /** The on-chain `ClusterInfo`, tracking epoch processing and the bot's lock. */
@@ -95,6 +98,12 @@ export interface ValidatorInfoAccount {
   failing_criteria: unknown[];
   stake_multiplier_bps: number;
   last_stake_change_epoch: unknown;
+  /**
+   * Penalty points for recent removals, not a removal count. A removal for poor
+   * performance adds `strike_decay_epochs` points and each eligible epoch works one
+   * off, so the value doubles as the good epochs left before the penalty clears.
+   */
+  removal_score: number;
 }
 
 /** Cached reader for this program's on-chain accounts. */

--- a/src/lib/delegation/configFields.ts
+++ b/src/lib/delegation/configFields.ts
@@ -31,6 +31,25 @@ const formatLamports = (value: unknown): string => {
 const formatBool = (value: unknown): string => (value ? 'Enabled' : 'Disabled');
 
 /**
+ * Basis points shown as the percentage an operator would recognise. Zero is
+ * called out, because for the strike fields it means the penalty is switched off
+ * rather than simply set to nothing.
+ */
+const formatBpsAsPercent = (value: unknown): string => {
+  const n = toNumber(value);
+  if (n === null) return '—';
+  if (n === 0) return 'Disabled';
+  return `${n / 100}%`;
+};
+
+const formatEpochs = (value: unknown): string => {
+  const n = toNumber(value);
+  if (n === null) return '—';
+  if (n === 0) return 'Disabled';
+  return n === 1 ? '1 epoch' : `${n} epochs`;
+};
+
+/**
  * Every field of `UpdateConfigParams`, in the order the program declares them.
  * The summary renders straight from this list, so a new config parameter only
  * needs an entry here plus a refreshed IDL.
@@ -119,5 +138,26 @@ export const CONFIG_FIELDS: ConfigFieldSpec[] = [
     label: 'Min stake adjustment',
     description: "Smallest change that triggers a rebalance of a validator's stake",
     format: formatPercent,
+  },
+  {
+    key: 'strike_penalty_bps',
+    label: 'Repeat removal penalty',
+    description:
+      'Delegation ceiling taken away for each recent removal for poor performance. Zero switches the penalty off entirely',
+    format: formatBpsAsPercent,
+  },
+  {
+    key: 'strike_min_cap_bps',
+    label: 'Repeat removal floor',
+    description:
+      'Lowest ceiling the repeat removal penalty can impose, no matter how many times a validator has been removed',
+    format: formatBpsAsPercent,
+  },
+  {
+    key: 'strike_decay_epochs',
+    label: 'Repeat removal decay',
+    description:
+      'Good epochs that work off a single removal. Zero switches the penalty off entirely',
+    format: formatEpochs,
   },
 ];

--- a/src/lib/idls/delegation_program.json
+++ b/src/lib/idls/delegation_program.json
@@ -1497,6 +1497,98 @@
       ]
     },
     {
+      "name": "update_validator_removal_score",
+      "docs": [
+        "Update a validator's repeat-removal penalty score (admin or bot authority)",
+        "",
+        "The score is penalty points, not a removal count: a removal for failing performance",
+        "criteria adds `strike_decay_epochs` points and every eligible epoch removes one. The",
+        "caller computes the new value; this instruction is a plain setter so the arithmetic",
+        "stays in one place off-chain."
+      ],
+      "discriminator": [
+        234,
+        7,
+        212,
+        199,
+        237,
+        82,
+        84,
+        255
+      ],
+      "accounts": [
+        {
+          "name": "validator",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  118,
+                  97,
+                  108,
+                  105,
+                  100,
+                  97,
+                  116,
+                  111,
+                  114
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "validator.vote_account",
+                "account": "ValidatorInfo"
+              }
+            ]
+          }
+        },
+        {
+          "name": "config",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  100,
+                  101,
+                  108,
+                  101,
+                  103,
+                  97,
+                  116,
+                  105,
+                  111,
+                  110,
+                  95,
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "signer",
+          "docs": [
+            "The signer (either admin authority or bot authority)"
+          ],
+          "signer": true
+        }
+      ],
+      "args": [
+        {
+          "name": "removal_score",
+          "type": "u8"
+        }
+      ]
+    },
+    {
       "name": "update_validator_status",
       "docs": [
         "Rewrite a validator account to the provided state (admin or reviewer authority)",
@@ -2005,6 +2097,33 @@
             "type": "pubkey"
           },
           {
+            "name": "strike_penalty_bps",
+            "docs": [
+              "Basis points of delegation removed from a validator's ceiling per recent removal.",
+              "With 2000, one removal caps a validator at 80% of normal delegation, two at 60%."
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "strike_min_cap_bps",
+            "docs": [
+              "Floor for the penalised ceiling, in basis points. A validator can never be pushed",
+              "below this no matter how many times it has been removed."
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "strike_decay_epochs",
+            "docs": [
+              "Good epochs required to work off a single removal. Also the number of penalty points",
+              "a removal adds to `ValidatorInfo::removal_score`.",
+              "",
+              "Zero disables the whole mechanism, which is what configs created before this field",
+              "existed read out of `_reserved`."
+            ],
+            "type": "u8"
+          },
+          {
             "name": "_reserved",
             "docs": [
               "Reserved space for future use"
@@ -2012,7 +2131,7 @@
             "type": {
               "array": [
                 "u8",
-                480
+                475
               ]
             }
           }
@@ -2151,6 +2270,24 @@
             "type": {
               "option": "u8"
             }
+          },
+          {
+            "name": "strike_penalty_bps",
+            "type": {
+              "option": "u16"
+            }
+          },
+          {
+            "name": "strike_min_cap_bps",
+            "type": {
+              "option": "u16"
+            }
+          },
+          {
+            "name": "strike_decay_epochs",
+            "type": {
+              "option": "u8"
+            }
           }
         ]
       }
@@ -2231,6 +2368,21 @@
             "type": "u64"
           },
           {
+            "name": "removal_score",
+            "docs": [
+              "Penalty points for recent removals from the delegation pool.",
+              "",
+              "This is NOT a raw removal count. A removal for failing performance criteria adds",
+              "`DelegationConfig::strike_decay_epochs` points, and every epoch the validator is",
+              "eligible removes one. Divide by `strike_decay_epochs` to get the removal count",
+              "(see `strike_tier`); the value itself is the number of good epochs remaining",
+              "before the penalty is fully cleared.",
+              "",
+              "Carved out of `_reserved` so the account size is unchanged for deployed validators."
+            ],
+            "type": "u8"
+          },
+          {
             "name": "_reserved",
             "docs": [
               "Reserved space for future use"
@@ -2238,7 +2390,7 @@
             "type": {
               "array": [
                 "u8",
-                502
+                500
               ]
             }
           }

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -59,6 +59,7 @@ import {
   DelegationUpdateValidatorStatusSummary,
   DelegationUpdateValidatorCriteriaSummary,
   DelegationUpdateValidatorMultiplierSummary,
+  DelegationUpdateValidatorRemovalScoreSummary,
   DelegationUpdateStakeChangeEpochSummary,
   DelegationInitializeConfigSummary,
   DelegationTransferAuthoritySummary,
@@ -308,6 +309,10 @@ registry.register({
     update_validator_multiplier: {
       summary: DelegationUpdateValidatorMultiplierSummary,
       tags: { label: 'Stake Multiplier', color: 'purple', variant: 'subtle' },
+    },
+    update_validator_removal_score: {
+      summary: DelegationUpdateValidatorRemovalScoreSummary,
+      tags: { label: 'Removal Penalty', color: 'amber', variant: 'subtle' },
     },
     update_stake_change_epoch: {
       summary: DelegationUpdateStakeChangeEpochSummary,


### PR DESCRIPTION
## Why

The delegation program added a repeat-removal penalty ([x1-labs/delegation-program#84](https://github.com/x1-labs/delegation-program/pull/84)): a per-validator `removal_score`, three `strike_*` parameters on `DelegationConfig`, and a new `update_validator_removal_score` instruction.

Without a refreshed IDL, those proposals decode as raw bytes in this UI — so a signer approving one would be approving something the interface cannot describe.

## Changes

- **Refreshed `src/lib/idls/delegation_program.json`** — 21 → 22 instructions, same program ID (`x1Dp8D2X…`), copied from the program's `target/idl/`.
- **`accounts.ts`** — `DelegationConfigAccount` gains `strike_penalty_bps`, `strike_min_cap_bps`, `strike_decay_epochs`; `ValidatorInfoAccount` gains `removal_score`.
- **`configFields.ts`** — three `CONFIG_FIELDS` entries, so `update_config` proposals show the strike parameters with before/after values like every other field. This is exactly the extension point the file documents: *"a new config parameter only needs an entry here plus a refreshed IDL."*
- **New summary** for `update_validator_removal_score`, registered under a "Removal Penalty" tag.

## One judgement call worth flagging

The score is **penalty points, not a removal count** — a removal adds `strike_decay_epochs` points and each eligible epoch works one off. Rendering it raw would be accurate but useless: an approver seeing `removal score: 4 → 8` cannot tell what that does to the validator.

So the summary reads the on-chain config and derives what the number actually means:

| Field | Shown |
|---|---|
| Penalty points | `4 → 8` |
| Recent removals | `1 → 2` |
| Delegation ceiling | `80% → 60%` |

If the config cannot be read, the derived rows are omitted and the raw score still renders — the summary degrades rather than guessing.

Similarly, `0` in the strike fields means *the penalty is switched off*, not "zero percent", so those render as **Disabled** rather than `0%`. The penalty ships disabled and is enabled by the multisig, so this is the state a reviewer will actually encounter first.

## Testing

- `npx tsc --noEmit` — **0 errors in `src/`** (the remaining output is pre-existing `node_modules` type noise on `main`).
- `npm run build:mainnet` — compiles, only the pre-existing bundle-size warnings.

Not done: no proposal decoded against a live cluster. The summary's derived rows depend on `fetchDelegationConfig` returning the new fields, which is worth eyeballing once against a real `update_validator_removal_score` proposal.

`HASHES.md` and `CHANGELOG.md` are untouched, matching the original delegation-decoding commit (7ef1d5e) — those are maintained by release tooling.