### PR TITLE
fix: round the removal count up, matching strike_tier on-chain

### DIFF
--- a/src/components/instructions/summaries/delegation/ValidatorSummaries.tsx
+++ b/src/components/instructions/summaries/delegation/ValidatorSummaries.tsx
@@ -352,7 +352,10 @@ function describeRemovalScore(
   const minCapBps = toNumber(config.strike_min_cap_bps);
   if (!decayEpochs || !penaltyBps || minCapBps === null) return null;
 
-  const removals = Math.floor(score / decayEpochs);
+  // Rounds up, matching `strike_tier` on-chain: a removal holds its full weight until
+  // every one of its points is worked off. Rounding down here would tell a signer that a
+  // score of 5 means one removal at an 80% ceiling when the program applies two at 60%.
+  const removals = Math.ceil(score / decayEpochs);
   return {
     removals,
     capBps: Math.max(10000 - removals * penaltyBps, minCapBps),


### PR DESCRIPTION
`describeRemovalScore` derives the removal count with `Math.floor`, which matched the program when #21 was written.

The delegation program has since changed `strike_tier` to round up (x1-labs/delegation-program#84), so a removal now holds its full weight until all of its points are worked off, instead of lapsing after one good epoch.

Without this, a signer reviewing an `update_validator_removal_score` proposal for a score of 5 is shown **1 removal, 80% ceiling** when the program applies **2 removals, 60% ceiling** — understating the effect of the transaction being approved.

One-line change plus a comment recording why it rounds up. Typecheck error count is unchanged (126 before and after, all pre-existing).